### PR TITLE
Add link to video and gif tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ notebooks available here:
 
 https://github.com/tommyogden/notebooks-maxwellbloch#examples
 
+Tools for making videos and gifs (like the one above) of the solved field
+propagation are available here:
+
+https://github.com/tommyogden/notebooks-maxwellbloch#tools
+
 ## Documentation
 
 On the way…


### PR DESCRIPTION
Better to put these tools in the notebooks repo, so this issue just required a line and a link from the README.