### PR TITLE
Fix CI bench job: skip --benchmark-compare-fail when no baseline exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,18 @@ jobs:
             benchmark-${{ runner.os }}-
       - name: Run benchmark (two-level sech 2π)
         run: |
+          # Only add --benchmark-compare-fail when a baseline exists in the
+          # cache. On the first run the cache is empty so we just save;
+          # subsequent runs compare and fail on >25% mean regression.
+          if find .benchmarks -name "*.json" 2>/dev/null | grep -q .; then
+            COMPARE="--benchmark-compare --benchmark-compare-fail=mean:25%"
+          else
+            COMPARE=""
+          fi
           uv run pytest tests/bench_mb_solve.py::test_bench_two_level_sech_2pi \
             --benchmark-only \
             --benchmark-save=ci \
-            --benchmark-compare \
-            --benchmark-compare-fail=mean:25%
+            $COMPARE
       - name: Save benchmark cache
         # Only update the baseline when the benchmark passes; a regression
         # (failed compare) leaves the previous baseline intact.


### PR DESCRIPTION
## Summary

- On first run (empty cache), `--benchmark-compare` finds no files and `--benchmark-compare-fail` raises `UsageError: --benchmark-compare-fail requires valid --benchmark-compare`
- Fix: check whether any `.benchmarks/*.json` files exist before adding the compare flags; first run just saves a baseline, subsequent runs compare and fail on >25% mean regression

## Test plan

- [ ] CI passes on this PR (first run — no cached baseline, should just save)
- [ ] CI passes on a subsequent push (baseline now cached, should compare)

🤖 Generated with [Claude Code](https://claude.com/claude-code)