### PR TITLE
GH#178: prefix internal methods with underscore across all modules

### DIFF
--- a/docs/examples/mbs-two-sech-2pi-collision.ipynb
+++ b/docs/examples/mbs-two-sech-2pi-collision.ipynb
@@ -89,7 +89,7 @@
     "    \"width_1\": t_width_1,\n",
     "}\n",
     "\n",
-    "mbs.atom.build_H_Omega()  # We have to rebuild H_Omega\n",
+    "mbs.atom.build_operators()  # Rebuild operators so H_Omega reflects new t_func\n",
     "mbs.init_Omegas_zt();"
    ]
   },

--- a/src/maxwellbloch/field.py
+++ b/src/maxwellbloch/field.py
@@ -50,7 +50,7 @@ class Field(object):
 
         self.coupled_levels = coupled_levels  # TODO should I convert to array?
 
-        self.build_factors(factors)
+        self._build_factors(factors)
 
         self.detuning = detuning
         self.detuning_positive = detuning_positive
@@ -83,7 +83,7 @@ class Field(object):
             self.rabi_freq_t_args,
         )
 
-    def build_factors(self, factors: list[float]) -> list[float]:
+    def _build_factors(self, factors: list[float]) -> list[float]:
         """Builds the factors list.
 
         Args:

--- a/src/maxwellbloch/mb_solve.py
+++ b/src/maxwellbloch/mb_solve.py
@@ -53,7 +53,7 @@ class MBSolve(ob_solve.OBSolve):
             z_min=z_min, z_max=z_max, z_steps=z_steps, z_steps_inner=z_steps_inner
         )
 
-        self.build_number_density(
+        self._build_number_density(
             interaction_strengths=interaction_strengths,
             num_density_z_func=num_density_z_func,
             num_density_z_args=num_density_z_args,
@@ -184,7 +184,7 @@ class MBSolve(ob_solve.OBSolve):
         )
         return self.thermal_delta_list, self.thermal_weights
 
-    def build_number_density(
+    def _build_number_density(
         self,
         interaction_strengths: list[float],
         num_density_z_func: str | None = None,
@@ -323,7 +323,7 @@ class MBSolve(ob_solve.OBSolve):
         # For the interpolation
         rabi_freq_ones = np.ones(len(self.atom.fields))
         # Set initial states at z=0
-        self.states_zt[0, :] = self.solve_and_average_over_thermal_detunings()
+        self.states_zt[0, :] = self._solve_and_average_over_thermal_detunings()
         # NOTE: This means the first z gets ob solved twice.
         # Can I avoid?
         ### All Steps:
@@ -335,20 +335,22 @@ class MBSolve(ob_solve.OBSolve):
             ### Inner z loop
             for _jj in range(self.z_steps_inner):
                 z_next = z_this + self.z_step_inner()
-                thermal_states_t = self.solve_and_average_over_thermal_detunings()
+                thermal_states_t = self._solve_and_average_over_thermal_detunings()
                 sum_coh_this = self.atom.get_fields_sum_coherence(
                     states_t=thermal_states_t
                 )
-                Omegas_z_next = self.z_step_fields_euler(
+                Omegas_z_next = self._z_step_fields_euler(
                     z_this=z_this,
                     z_next=z_next,
                     Omegas_z_this=Omegas_z_this,
                     sum_coh_this=sum_coh_this,
                 )
-                Omegas_z_next_args = self.get_Omegas_intp_t_args(Omegas_z=Omegas_z_next)
+                Omegas_z_next_args = self._get_Omegas_intp_t_args(
+                    Omegas_z=Omegas_z_next
+                )
                 self.atom.set_H_Omega(
                     rabi_freqs=rabi_freq_ones,
-                    rabi_freq_t_funcs=self.get_Omegas_intp_t_funcs(),
+                    rabi_freq_t_funcs=self._get_Omegas_intp_t_funcs(),
                     rabi_freq_t_args=Omegas_z_next_args,
                 )
                 # Set up for next inner step
@@ -382,7 +384,7 @@ class MBSolve(ob_solve.OBSolve):
         # For use in the loop
         rabi_freq_ones = np.ones(len(self.atom.fields))
         # Set initial states at z=0
-        thermal_states_t = self.solve_and_average_over_thermal_detunings()
+        thermal_states_t = self._solve_and_average_over_thermal_detunings()
         self.states_zt[0, :] = thermal_states_t
         # We won't need these until the first AB step
         sum_coh_prev = self.atom.get_fields_sum_coherence(states_t=thermal_states_t)
@@ -394,16 +396,16 @@ class MBSolve(ob_solve.OBSolve):
         Omegas_z_this = self.Omegas_zt[:, j, :]
         z_this = z
         z_next = z_this + self.z_step_inner()
-        Omegas_z_next = self.z_step_fields_euler(
+        Omegas_z_next = self._z_step_fields_euler(
             z_this=z_this,
             z_next=z_next,
             Omegas_z_this=Omegas_z_this,
             sum_coh_this=sum_coh_prev,
         )
-        Omegas_z_next_args = self.get_Omegas_intp_t_args(Omegas_z=Omegas_z_next)
+        Omegas_z_next_args = self._get_Omegas_intp_t_args(Omegas_z=Omegas_z_next)
         self.atom.set_H_Omega(
             rabi_freqs=rabi_freq_ones,
-            rabi_freq_t_funcs=self.get_Omegas_intp_t_funcs(),
+            rabi_freq_t_funcs=self._get_Omegas_intp_t_funcs(),
             rabi_freq_t_args=Omegas_z_next_args,
         )
         self.states_zt[j + 1, :] = self.states_t()
@@ -417,11 +419,11 @@ class MBSolve(ob_solve.OBSolve):
             ### Inner z loop
             for _jj in range(self.z_steps_inner):
                 z_next = z_this + self.z_step_inner()
-                thermal_states_t = self.solve_and_average_over_thermal_detunings()
+                thermal_states_t = self._solve_and_average_over_thermal_detunings()
                 sum_coh_this = self.atom.get_fields_sum_coherence(
                     states_t=thermal_states_t
                 )
-                Omegas_z_next = self.z_step_fields_ab(
+                Omegas_z_next = self._z_step_fields_ab(
                     z_prev=z_prev,
                     z_this=z_this,
                     z_next=z_next,
@@ -429,10 +431,10 @@ class MBSolve(ob_solve.OBSolve):
                     sum_coh_this=sum_coh_this,
                     Omegas_z_this=Omegas_z_this,
                 )
-                Omegas_z_next_args = self.get_Omegas_intp_t_args(Omegas_z_next)
+                Omegas_z_next_args = self._get_Omegas_intp_t_args(Omegas_z_next)
                 self.atom.set_H_Omega(
                     rabi_freqs=rabi_freq_ones,
-                    rabi_freq_t_funcs=self.get_Omegas_intp_t_funcs(),
+                    rabi_freq_t_funcs=self._get_Omegas_intp_t_funcs(),
                     rabi_freq_t_args=Omegas_z_next_args,
                 )
                 # Set up for next inner step
@@ -446,7 +448,7 @@ class MBSolve(ob_solve.OBSolve):
             self.Omegas_zt[:, j + 1, :] = Omegas_z_next
         return self.Omegas_zt, self.states_zt
 
-    def z_step_fields_euler(
+    def _z_step_fields_euler(
         self,
         z_this: float,
         z_next: float,
@@ -471,7 +473,7 @@ class MBSolve(ob_solve.OBSolve):
         dOmega_dz = 1.0j * N * self.g[:, None] * sum_coh_this
         return Omegas_z_this + h * dOmega_dz
 
-    def z_step_fields_ab(
+    def _z_step_fields_ab(
         self,
         z_prev: float,
         z_this: float,
@@ -499,7 +501,7 @@ class MBSolve(ob_solve.OBSolve):
         dOmega_dz_prev = 1.0j * N * self.g[:, None] * sum_coh_prev
         return Omegas_z_this + 1.5 * h * dOmega_dz_this - 0.5 * h * dOmega_dz_prev
 
-    def get_Omegas_intp_t_funcs(self) -> list[str]:
+    def _get_Omegas_intp_t_funcs(self) -> list[str]:
         """Gets a list of strings representing the interpolation t_funcs for
         use the MB solver, which needs a function representing the field
         at a z step to perform the next master equation solver.
@@ -508,7 +510,7 @@ class MBSolve(ob_solve.OBSolve):
         """
         return ["intp" for f in self.atom.fields]
 
-    def get_Omegas_intp_t_args(self, Omegas_z: np.ndarray) -> list[dict]:
+    def _get_Omegas_intp_t_args(self, Omegas_z: np.ndarray) -> list[dict]:
         """Return the values of Omegas at a given point as a list of
         args for interpolation
 
@@ -527,7 +529,7 @@ class MBSolve(ob_solve.OBSolve):
             }
         return fields_args
 
-    def solve_and_average_over_thermal_detunings(self) -> np.ndarray:
+    def _solve_and_average_over_thermal_detunings(self) -> np.ndarray:
         """Solves the Lindblad equation for the OBAtom over a range of
             detuning shifts for velocity classes.
 

--- a/src/maxwellbloch/ob_atom.py
+++ b/src/maxwellbloch/ob_atom.py
@@ -113,13 +113,13 @@ class OBAtom(ob_base.OBBase):
         collapse operators and interaction Hamiltonian.
         """
 
-        self.build_H_0()
-        self.build_c_ops()
-        self.build_H_Delta()
-        self.build_H_Omega()
+        self._build_H_0()
+        self._build_c_ops()
+        self._build_H_Delta()
+        self._build_H_Omega()
         self._build_sum_coherence_arrays()
 
-    def build_H_0(self) -> qu.Qobj:
+    def _build_H_0(self) -> qu.Qobj:
         """Makes a Bare Hamiltonian with the energies as diagonals.
 
         Leave the list empty for all zero energies (i.e. if you don't care
@@ -140,7 +140,7 @@ class OBAtom(ob_base.OBBase):
         self.H_0 = qu.Qobj(H_0)
         return self.H_0
 
-    def build_c_ops(self) -> list[qu.Qobj]:
+    def _build_c_ops(self) -> list[qu.Qobj]:
         """Takes the list of decays and makes a list of collapse operators to
             be passed to the solver.
 
@@ -173,7 +173,7 @@ class OBAtom(ob_base.OBBase):
                     )
         return self.c_ops
 
-    def build_H_Delta(self) -> qu.Qobj:
+    def _build_H_Delta(self) -> qu.Qobj:
         """Builds the detuning part of the interaction Hamiltonian."""
 
         self.H_Delta = qu.Qobj(np.zeros([self.num_states, self.num_states]))
@@ -199,9 +199,9 @@ class OBAtom(ob_base.OBBase):
         assert len(detunings) == len(self.fields)
         for i, f in enumerate(self.fields):
             f.detuning = detunings[i]
-        return self.build_H_Delta()
+        return self._build_H_Delta()
 
-    def build_H_Omega(self) -> list:
+    def _build_H_Omega(self) -> list:
         """Builds the Rabi frequency (off-diagonals) part of the interaction
         Hamiltonian.
         """
@@ -248,7 +248,7 @@ class OBAtom(ob_base.OBBase):
             f.build_rabi_freq_t_func(rabi_freq_t_func=rabi_freq_t_funcs[f_i], index=f_i)
             f.build_rabi_freq_t_args(rabi_freq_t_args=rabi_freq_t_args[f_i], index=f_i)
 
-        return self.build_H_Omega()
+        return self._build_H_Omega()
 
     def get_detunings(self) -> list[float]:
         """Returns a list of detunings, one for each field in fields."""

--- a/src/maxwellbloch/ob_solve.py
+++ b/src/maxwellbloch/ob_solve.py
@@ -45,14 +45,14 @@ class OBSolve(object):
         if atom is None:
             atom = {}
 
-        self.build_atom(atom)
+        self._build_atom(atom)
 
-        self.build_tlist(t_min=t_min, t_max=t_max, t_steps=t_steps)
+        self._build_tlist(t_min=t_min, t_max=t_max, t_steps=t_steps)
 
         self.method = method
         self.build_opts(opts)
 
-        self.build_savefile(savefile)
+        self._build_savefile(savefile)
 
     def __repr__(self):
         return (
@@ -66,12 +66,12 @@ class OBSolve(object):
             self.atom, self.t_min, self.t_max, self.t_steps, self.method, self.opts
         )
 
-    def build_atom(self, atom_dict: dict) -> ob_atom.OBAtom:
+    def _build_atom(self, atom_dict: dict) -> ob_atom.OBAtom:
 
         self.atom = ob_atom.OBAtom(**atom_dict)
         return self.atom
 
-    def build_tlist(self, t_min: float, t_max: float, t_steps: int) -> np.ndarray:
+    def _build_tlist(self, t_min: float, t_max: float, t_steps: int) -> np.ndarray:
 
         from numpy import linspace
 
@@ -180,7 +180,7 @@ class OBSolve(object):
 
         return (self.t_max - self.t_min) / self.t_steps
 
-    def build_savefile(self, savefile: str | None) -> None:
+    def _build_savefile(self, savefile: str | None) -> None:
 
         self.savefile = savefile
 

--- a/tests/test_mb_solve.py
+++ b/tests/test_mb_solve.py
@@ -317,7 +317,7 @@ class TestGetOmegasIntpTFuncs(unittest.TestCase):
         json_path = os.path.join(JSON_DIR, "mb_solve_01.json")
         mb_solve_00 = mb_solve.MBSolve().from_json(json_path)
 
-        self.assertEqual(mb_solve_00.get_Omegas_intp_t_funcs(), ["intp"])
+        self.assertEqual(mb_solve_00._get_Omegas_intp_t_funcs(), ["intp"])
 
     def test_two_fields(self):
         """For the case of two fields"""
@@ -325,7 +325,7 @@ class TestGetOmegasIntpTFuncs(unittest.TestCase):
         json_path = os.path.join(JSON_DIR, "mb_solve_lamda.json")
         mb_solve_lamda = mb_solve.MBSolve().from_json(json_path)
 
-        self.assertEqual(mb_solve_lamda.get_Omegas_intp_t_funcs(), ["intp", "intp"])
+        self.assertEqual(mb_solve_lamda._get_Omegas_intp_t_funcs(), ["intp", "intp"])
 
 
 class TestGetOmegasIntpTArgs(unittest.TestCase):
@@ -339,7 +339,7 @@ class TestGetOmegasIntpTArgs(unittest.TestCase):
 
         Omegas_z = mb_solve_00.Omegas_zt[:, 0, :]
 
-        t_args = mb_solve_00.get_Omegas_intp_t_args(Omegas_z)
+        t_args = mb_solve_00._get_Omegas_intp_t_args(Omegas_z)
 
         self.assertEqual(len(t_args), 1)
 


### PR DESCRIPTION
## Summary

Clarifies the public API by prefixing purely internal methods with `_` throughout:

| Module | Methods privatised |
|---|---|
| `mb_solve.py` | `_build_number_density`, `_solve_and_average_over_thermal_detunings`, `_z_step_fields_euler`, `_z_step_fields_ab`, `_get_Omegas_intp_t_funcs`, `_get_Omegas_intp_t_args` |
| `ob_atom.py` | `_build_H_0`, `_build_c_ops`, `_build_H_Delta`, `_build_H_Omega` |
| `ob_solve.py` | `_build_atom`, `_build_tlist`, `_build_savefile` |
| `field.py` | `_build_factors` |

Public methods kept as-is: `build_operators`, `build_fields`, `build_initial_state`, `build_velocity_classes`, `build_zlist`, `build_opts` (called at solve time or directly in tests/notebooks).

The notebook `mbs-two-sech-2pi-collision.ipynb` used `build_H_Omega()` directly — updated to `build_operators()`. Verified that `Omegas_zt` is identical between the two approaches (max diff = 0.0).

## Test plan

- [ ] `uv run pytest -n auto` — 109 passed
- [ ] `_get_Omegas_intp_t_funcs` / `_get_Omegas_intp_t_args` tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)