### PR TITLE
GH#157, GH#151: Field.upper/lower_levels(); LevelF F-range validation; coherences vectorised

### DIFF
--- a/src/maxwellbloch/field.py
+++ b/src/maxwellbloch/field.py
@@ -83,6 +83,22 @@ class Field(object):
             self.rabi_freq_t_args,
         )
 
+    def lower_levels(self) -> list[int]:
+        """Return the unique lower (ground) level indices coupled by this field.
+
+        Returns:
+            Sorted list of unique indices ``c[0]`` from ``coupled_levels``.
+        """
+        return sorted(set(c[0] for c in self.coupled_levels))
+
+    def upper_levels(self) -> list[int]:
+        """Return the unique upper (excited) level indices coupled by this field.
+
+        Returns:
+            Sorted list of unique indices ``c[1]`` from ``coupled_levels``.
+        """
+        return sorted(set(c[1] for c in self.coupled_levels))
+
     def _build_factors(self, factors: list[float]) -> list[float]:
         """Builds the factors list.
 

--- a/src/maxwellbloch/hyperfine.py
+++ b/src/maxwellbloch/hyperfine.py
@@ -238,8 +238,8 @@ class LevelF(object):
 
     Notes:
         - The magnitude of F can take values in the range
-            `|J - I| <= F <= J + I`.
-        TODO: Now we have I, J in this class, throw if this is not met.
+            `|J - I| <= F <= J + I`. A ``ValueError`` is raised if this is
+            not satisfied.
         - The mF_energies are set _relative_ to the F level energy.
     """
 
@@ -256,6 +256,15 @@ class LevelF(object):
         self.J = J
         self.F = F
         self.energy = energy
+
+        F_min = abs(J - I)
+        F_max = J + I
+        if not (F_min <= F <= F_max):
+            raise ValueError(
+                f"F={F} is outside the allowed range |J-I| <= F <= J+I "
+                f"(|{J}-{I}| = {F_min:.1f}, {J}+{I} = {F_max:.1f})."
+            )
+
         self.build_mF_levels(mF_energies)
 
     def __repr__(self):

--- a/src/maxwellbloch/mb_solve.py
+++ b/src/maxwellbloch/mb_solve.py
@@ -617,12 +617,9 @@ class MBSolve(ob_solve.OBSolve):
         Note:
             - Casting upper to int so upper is 1, lower is 0.
         """
-        # TODO: This is also used in H_Delta. Really, lower_levels and
-        # upper_levels could be methods of Field.
-        upper_levels = list(
-            set(c[int(upper)] for c in self.atom.fields[field_idx].coupled_levels)
-        )
-        return self.populations(upper_levels)
+        f = self.atom.fields[field_idx]
+        levels = f.upper_levels() if upper else f.lower_levels()
+        return self.populations(levels)
 
     def coherences(self, coupled_levels: list[list[int]]) -> np.ndarray:
         """Gets the sum of coherences (off-diagonals) in a list of coupled
@@ -630,17 +627,18 @@ class MBSolve(ob_solve.OBSolve):
 
         Args:
             coupled_levels: a list of pairs of level indexes
+
         Returns:
             np.array, shape (z_steps+1, t_steps+1), dtype=complex
 
-        #TODO: This is repeating OBAtom.get_fields_sum_coherence. Decide
-        #   what to do about this!
+        Note:
+            Unlike ``OBAtom.get_fields_sum_coherence``, which operates on a
+            single-z time series with per-field weighting factors, this method
+            sums over the full (z, t) array with unit weights.
         """
-
-        sum_coh = np.zeros(self.states_zt.shape[:2], dtype=complex)
-        for cl in coupled_levels:
-            sum_coh += self.states_zt[:, :, cl[0], cl[1]]
-        return sum_coh
+        rows = [cl[0] for cl in coupled_levels]
+        cols = [cl[1] for cl in coupled_levels]
+        return self.states_zt[:, :, rows, cols].sum(axis=2)
 
     def coherences_field(self, field_idx: int) -> np.ndarray:
         """Get the sum of coherences (off-diagonals) for the levels coupled by

--- a/src/maxwellbloch/ob_atom.py
+++ b/src/maxwellbloch/ob_atom.py
@@ -182,10 +182,7 @@ class OBAtom(ob_base.OBBase):
                 sgn = 1.0
             else:
                 sgn = -1.0
-            # Only want the unique upper levels if the field has multiple
-            # channels.
-            upper_levels = set(c[1] for c in f.coupled_levels)
-            for i in upper_levels:
+            for i in f.upper_levels():
                 self.H_Delta -= sgn * 2 * pi * f.detuning * self.sigma(a=i, b=i)
         return self.H_Delta
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -109,6 +109,38 @@ class TestInit(unittest.TestCase):
         self.assertEqual(self.field_02.to_json_str(), field_03.to_json_str())
 
 
+class TestUpperLowerLevels(unittest.TestCase):
+    """Unit tests for Field.upper_levels() and Field.lower_levels()."""
+
+    def test_single_channel(self):
+        f = field.Field(coupled_levels=[[0, 1]])
+        self.assertEqual(f.lower_levels(), [0])
+        self.assertEqual(f.upper_levels(), [1])
+
+    def test_multi_channel_single_upper(self):
+        """Two lower levels coupling to one upper level."""
+        f = field.Field(coupled_levels=[[0, 2], [1, 2]])
+        self.assertEqual(f.lower_levels(), [0, 1])
+        self.assertEqual(f.upper_levels(), [2])
+
+    def test_multi_channel_single_lower(self):
+        """One lower level coupling to two upper levels."""
+        f = field.Field(coupled_levels=[[0, 1], [0, 2]])
+        self.assertEqual(f.lower_levels(), [0])
+        self.assertEqual(f.upper_levels(), [1, 2])
+
+    def test_output_is_sorted(self):
+        """Results are always in ascending index order."""
+        f = field.Field(coupled_levels=[[2, 4], [0, 3]])
+        self.assertEqual(f.lower_levels(), [0, 2])
+        self.assertEqual(f.upper_levels(), [3, 4])
+
+    def test_empty_coupled_levels(self):
+        f = field.Field(coupled_levels=[])
+        self.assertEqual(f.lower_levels(), [])
+        self.assertEqual(f.upper_levels(), [])
+
+
 class TestBuildRabiFreqTFunc(unittest.TestCase):
     field_00 = field.Field()
 

--- a/tests/test_hyperfine.py
+++ b/tests/test_hyperfine.py
@@ -468,3 +468,40 @@ class TestLevelFInit(unittest.TestCase):
         self.assertEqual(len(lf.mF_levels), 2 * F + 1)
         for i, e in enumerate(mF_energies):
             self.assertEqual(e, lf.mF_levels[i].energy)
+
+
+class TestLevelFValidation(unittest.TestCase):
+    """GH#151: LevelF.__init__ must enforce |J - I| <= F <= J + I."""
+
+    def test_valid_F_at_min(self):
+        """F = |J - I| is the minimum allowed value."""
+        # I=1.5, J=0.5 → F_min=1, F_max=2
+        lf = hyperfine.LevelF(I=1.5, J=0.5, F=1)
+        self.assertEqual(lf.F, 1)
+
+    def test_valid_F_at_max(self):
+        """F = J + I is the maximum allowed value."""
+        lf = hyperfine.LevelF(I=1.5, J=0.5, F=2)
+        self.assertEqual(lf.F, 2)
+
+    def test_valid_F_intermediate(self):
+        """F between min and max is allowed (I=1.5, J=2.5 → F in {1,2,3,4})."""
+        for F in [1, 2, 3, 4]:
+            hyperfine.LevelF(I=1.5, J=2.5, F=F)  # should not raise
+
+    def test_F_too_large_raises(self):
+        """F > J + I must raise ValueError."""
+        with self.assertRaises(ValueError):
+            hyperfine.LevelF(I=1.5, J=0.5, F=3)  # F_max = 2
+
+    def test_F_too_small_raises(self):
+        """F < |J - I| must raise ValueError."""
+        with self.assertRaises(ValueError):
+            hyperfine.LevelF(I=1.5, J=0.5, F=0)  # F_min = 1
+
+    def test_error_message_contains_values(self):
+        """ValueError message should include I, J, F and the bounds."""
+        with self.assertRaises(ValueError, msg="F=3") as ctx:
+            hyperfine.LevelF(I=1.5, J=0.5, F=3)
+        self.assertIn("F=3", str(ctx.exception))
+        self.assertIn("J+I", str(ctx.exception))


### PR DESCRIPTION
## Summary

Three related code quality fixes in one PR:

**GH#157 — `Field.upper_levels()` / `lower_levels()`**
- New methods returning sorted unique upper/lower level indices from `coupled_levels`
- `ob_atom._build_H_Delta` and `mb_solve.populations_field` updated to use them (removes two TODO comments)

**GH#151 — `LevelF` F-range validation**
- `LevelF.__init__` now raises `ValueError` if `F` violates `|J - I| <= F <= J + I`
- Error message includes F, the bounds, and the computed min/max
- TODO in docstring replaced with a proper note

**`mb_solve.coherences` cleanup**
- Vectorised: `rows/cols` index arrays + `.sum(axis=2)` replaces Python loop
- Stale TODO replaced with a note clarifying why it's different from `OBAtom.get_fields_sum_coherence` (different shape, no weighting factors)

## Test plan

- [ ] `uv run pytest -n auto` — 131 passed (was 109 before test PRs, +22 new tests across all recent PRs)
- [ ] `uv run pytest tests/test_field.py::TestUpperLowerLevels -v` — 5 tests
- [ ] `uv run pytest tests/test_hyperfine.py::TestLevelFValidation -v` — 6 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)