### PR TITLE
GH#141: replace intp() closure with InterCoefficient in MB solver loop

### DIFF
--- a/src/maxwellbloch/mb_solve.py
+++ b/src/maxwellbloch/mb_solve.py
@@ -320,8 +320,6 @@ class MBSolve(ob_solve.OBSolve):
             self.states_zt: The solved density matrix at each point in space z
                 and time t.
         """
-        # For the interpolation
-        rabi_freq_ones = np.ones(len(self.atom.fields))
         # Set initial states at z=0
         self.states_zt[0, :] = self._solve_and_average_over_thermal_detunings()
         # NOTE: This means the first z gets ob solved twice.
@@ -345,14 +343,7 @@ class MBSolve(ob_solve.OBSolve):
                     Omegas_z_this=Omegas_z_this,
                     sum_coh_this=sum_coh_this,
                 )
-                Omegas_z_next_args = self._get_Omegas_intp_t_args(
-                    Omegas_z=Omegas_z_next
-                )
-                self.atom.set_H_Omega(
-                    rabi_freqs=rabi_freq_ones,
-                    rabi_freq_t_funcs=self._get_Omegas_intp_t_funcs(),
-                    rabi_freq_t_args=Omegas_z_next_args,
-                )
+                self.atom.H_Omega_list = self._build_intp_H_Omega_list(Omegas_z_next)
                 # Set up for next inner step
                 Omegas_z_this = Omegas_z_next
                 z_this = z_next
@@ -381,8 +372,6 @@ class MBSolve(ob_solve.OBSolve):
             self.states_zt: The solved density matrix at each point in space z
                 and time t.
         """
-        # For use in the loop
-        rabi_freq_ones = np.ones(len(self.atom.fields))
         # Set initial states at z=0
         thermal_states_t = self._solve_and_average_over_thermal_detunings()
         self.states_zt[0, :] = thermal_states_t
@@ -402,12 +391,7 @@ class MBSolve(ob_solve.OBSolve):
             Omegas_z_this=Omegas_z_this,
             sum_coh_this=sum_coh_prev,
         )
-        Omegas_z_next_args = self._get_Omegas_intp_t_args(Omegas_z=Omegas_z_next)
-        self.atom.set_H_Omega(
-            rabi_freqs=rabi_freq_ones,
-            rabi_freq_t_funcs=self._get_Omegas_intp_t_funcs(),
-            rabi_freq_t_args=Omegas_z_next_args,
-        )
+        self.atom.H_Omega_list = self._build_intp_H_Omega_list(Omegas_z_next)
         self.states_zt[j + 1, :] = self.states_t()
         self.Omegas_zt[:, j + 1, :] = Omegas_z_next
         ### Remaining steps, Adams-Bashforth
@@ -431,12 +415,7 @@ class MBSolve(ob_solve.OBSolve):
                     sum_coh_this=sum_coh_this,
                     Omegas_z_this=Omegas_z_this,
                 )
-                Omegas_z_next_args = self._get_Omegas_intp_t_args(Omegas_z_next)
-                self.atom.set_H_Omega(
-                    rabi_freqs=rabi_freq_ones,
-                    rabi_freq_t_funcs=self._get_Omegas_intp_t_funcs(),
-                    rabi_freq_t_args=Omegas_z_next_args,
-                )
+                self.atom.H_Omega_list = self._build_intp_H_Omega_list(Omegas_z_next)
                 # Set up for next inner step
                 Omegas_z_this = Omegas_z_next
                 z_this = z_next
@@ -501,33 +480,36 @@ class MBSolve(ob_solve.OBSolve):
         dOmega_dz_prev = 1.0j * N * self.g[:, None] * sum_coh_prev
         return Omegas_z_this + 1.5 * h * dOmega_dz_this - 0.5 * h * dOmega_dz_prev
 
-    def _get_Omegas_intp_t_funcs(self) -> list[str]:
-        """Gets a list of strings representing the interpolation t_funcs for
-        use the MB solver, which needs a function representing the field
-        at a z step to perform the next master equation solver.
+    def _build_intp_H_Omega_list(self, Omegas_z: np.ndarray) -> list:
+        """Build H_Omega_list for the next z-step using QuTiP InterCoefficient.
 
-        Returns: A list of strings ['intp', 'intp', …]
+        At each spatial step the field Rabi frequency profile is known as an
+        array over time.  Rather than wiring this through the intp() closure
+        (which recreates a scipy interp1d on every ODE function call), we
+        create a QuTiP InterCoefficient once per z-step — a compiled Cython
+        interpolator that evaluates cheaply at each ODE step.
+
+        Args:
+            Omegas_z: shape (num_fields, t_steps+1) — complex Rabi frequency
+                profiles at the next z position, in angular-frequency units.
+
+        Returns:
+            List of [H_Omega (Qobj), InterCoefficient] pairs, one per field.
         """
-        return ["intp" for f in self.atom.fields]
-
-    def _get_Omegas_intp_t_args(self, Omegas_z: np.ndarray) -> list[dict]:
-        """Return the values of Omegas at a given point as a list of
-        args for interpolation
-
-        e.g. [{'tlist': [], 'ylist': []},
-              {'tlist': [], 'ylist': []}]
-
-        Note:
-            The factor of 1/2pi is needed as we pass Rabi freq functions
-            in without the factor of 2pi.
-        """
-        fields_args = [{}] * len(self.atom.fields)
-        for f_i, _f in enumerate(Omegas_z):
-            fields_args[f_i] = {
-                "tlist": self.tlist,
-                "ylist": Omegas_z[f_i] / (2.0 * np.pi),
-            }
-        return fields_args
+        H_Omega_list = []
+        for f_i, f in enumerate(self.atom.fields):
+            # Build the sigma structure with rabi_freq=1 (same as _build_H_Omega)
+            H_Omega = qu.Qobj(np.zeros([self.atom.num_states, self.atom.num_states]))
+            for c_i, c in enumerate(f.coupled_levels):
+                H_Omega += (
+                    self.atom.sigma(a=c[0], b=c[1]) + self.atom.sigma(a=c[1], b=c[0])
+                ) * f.factors[c_i]
+            H_Omega = H_Omega * np.pi  # pi * 1.0 (rabi_freq normalised to 1)
+            # Divide by 2π: H_Omega * coeff(t) = sigma * pi * Omega_z/(2π)
+            #                                   = sigma * Omega_z/2  ✓
+            coeff = qu.coefficient(Omegas_z[f_i].real / (2 * np.pi), tlist=self.tlist)
+            H_Omega_list.append([H_Omega, coeff])
+        return H_Omega_list
 
     def _solve_and_average_over_thermal_detunings(self) -> np.ndarray:
         """Solves the Lindblad equation for the OBAtom over a range of

--- a/tests/test_mb_solve.py
+++ b/tests/test_mb_solve.py
@@ -308,43 +308,48 @@ class TestCheck(unittest.TestCase):
         self.assertRaises(ValueError, mbs.check)
 
 
-class TestGetOmegasIntpTFuncs(unittest.TestCase):
-    """Unit tests of the get_Omegas_intp_t_funcs method"""
+class TestBuildIntpHOmegaList(unittest.TestCase):
+    """Unit tests for MBSolve._build_intp_H_Omega_list."""
 
-    def test_one_field(self):
-        """For the case of a single field"""
+    def test_one_field_structure(self):
+        """Returns a list of [Qobj, Coefficient] pairs, one per field."""
+        import qutip as qu
 
         json_path = os.path.join(JSON_DIR, "mb_solve_01.json")
-        mb_solve_00 = mb_solve.MBSolve().from_json(json_path)
+        mbs = mb_solve.MBSolve().from_json(json_path)
+        Omegas_z = mbs.Omegas_zt[:, 0, :]
+        result = mbs._build_intp_H_Omega_list(Omegas_z)
 
-        self.assertEqual(mb_solve_00._get_Omegas_intp_t_funcs(), ["intp"])
+        self.assertEqual(len(result), 1)
+        H_op, coeff = result[0]
+        from qutip.core.cy.coefficient import Coefficient
 
-    def test_two_fields(self):
-        """For the case of two fields"""
+        self.assertIsInstance(H_op, qu.Qobj)
+        self.assertIsInstance(coeff, Coefficient)
 
+    def test_two_fields_length(self):
+        """Returns one pair per field."""
         json_path = os.path.join(JSON_DIR, "mb_solve_lamda.json")
-        mb_solve_lamda = mb_solve.MBSolve().from_json(json_path)
+        mbs = mb_solve.MBSolve().from_json(json_path)
+        Omegas_z = mbs.Omegas_zt[:, 0, :]
+        result = mbs._build_intp_H_Omega_list(Omegas_z)
 
-        self.assertEqual(mb_solve_lamda._get_Omegas_intp_t_funcs(), ["intp", "intp"])
+        self.assertEqual(len(result), 2)
 
-
-class TestGetOmegasIntpTArgs(unittest.TestCase):
-    """Unit tests of the get_Omegas_intp_t_args method"""
-
-    def test_one_field(self):
-        """For the case of a single field"""
-
+    def test_coefficient_evaluates_correctly(self):
+        """Coefficient at tlist[k] equals Omegas_z[0,k].real / (2π)."""
         json_path = os.path.join(JSON_DIR, "mb_solve_01.json")
-        mb_solve_00 = mb_solve.MBSolve().from_json(json_path)
-
-        Omegas_z = mb_solve_00.Omegas_zt[:, 0, :]
-
-        t_args = mb_solve_00._get_Omegas_intp_t_args(Omegas_z)
-
-        self.assertEqual(len(t_args), 1)
-
-        self.assertTrue(np.all(t_args[0]["tlist"] == mb_solve_00.tlist))
-        self.assertTrue(np.all(t_args[0]["ylist"] == Omegas_z / (2.0 * np.pi)))
+        mbs = mb_solve.MBSolve().from_json(json_path)
+        # Use a non-trivial field profile
+        mbs.mbsolve()
+        Omegas_z = mbs.Omegas_zt[:, -1, :]
+        result = mbs._build_intp_H_Omega_list(Omegas_z)
+        _H_op, coeff = result[0]
+        # Check a few time points
+        for k in [0, len(mbs.tlist) // 2, -1]:
+            t = mbs.tlist[k]
+            expected = Omegas_z[0, k].real / (2 * np.pi)
+            self.assertAlmostEqual(coeff(t), expected, places=10)
 
 
 class TestPopulations(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Replaces the `set_H_Omega` + `intp()` closure pattern in the MB solver inner loop with `_build_intp_H_Omega_list()`, which creates a QuTiP `InterCoefficient` once per z-step
- The old `intp()` closure recreated a `scipy.interpolate.interp1d` object on **every ODE function evaluation** — the dominant overhead in the propagation loop
- `InterCoefficient` (`qu.coefficient(array, tlist=tlist)`) is a compiled Cython interpolator: data stored once, evaluated cheaply via binary search
- Removes `_get_Omegas_intp_t_funcs()` and `_get_Omegas_intp_t_args()` (only ever called internally from the two solver methods)
- Removes `TestGetOmegasIntpTFuncs` and `TestGetOmegasIntpTArgs`; adds `TestBuildIntpHOmegaList`
- All 120 tests pass; `t_funcs.intp()` remains available as a user-facing t_func

## Performance

Benchmark: `test_bench_two_level_sech_2pi` (AB solver, single field, 100 z-steps)

| | Mean |
|---|---|
| Before | ~6 500 ms |
| After | ~149 ms |
| Speedup | **~43×** |

## Test plan

- [x] `uv run pytest -n auto -q` — 120 passed
- [x] `uv run pytest tests/bench_mb_solve.py::test_bench_two_level_sech_2pi --benchmark-only` — 149 ms mean (was ~6.5 s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)