### PR TITLE
GH#195: create missing savefile directory before writing .qu file

### DIFF
--- a/src/maxwellbloch/mb_solve.py
+++ b/src/maxwellbloch/mb_solve.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 
+import os
+
 import numpy as np
 import qutip as qu
 
@@ -550,6 +552,7 @@ class MBSolve(ob_solve.OBSolve):
         """
         # Only save the file if we have a place to save it.
         if self.savefile:
+            os.makedirs(os.path.dirname(self.savefile) or ".", exist_ok=True)
             print("Saving MBSolve to", self.savefile + ".qu")
             qu.qsave((self.Omegas_zt, self.states_zt), self.savefile)
 

--- a/src/maxwellbloch/ob_base.py
+++ b/src/maxwellbloch/ob_base.py
@@ -195,8 +195,8 @@ class OBBase(object):
 
             # Only save the file if we have a place to save it.
             if savefile:
+                os.makedirs(os.path.dirname(savefile) or ".", exist_ok=True)
                 print("Saving OBBase to {0}.qu".format(savefile))
-
                 qu.qsave(self.result, savefile)
 
         # Otherwise load the steady state rho_v_delta from file

--- a/tests/test_mb_solve.py
+++ b/tests/test_mb_solve.py
@@ -277,6 +277,21 @@ class TestSaveLoad(unittest.TestCase):
         self.assertTrue((Omegas_zt == Omegas_zt_loaded).all())
         self.assertTrue((states_zt == states_zt_loaded).all())
 
+    def test_save_creates_missing_directory(self):
+        """GH#195: save_results must not error when the savefile directory
+        does not yet exist."""
+        import tempfile
+
+        json_path = os.path.join(JSON_DIR, "mb_solve_01.json")
+        mbs = mb_solve.MBSolve().from_json(json_path)
+        mbs.mbsolve()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            savefile = os.path.join(tmpdir, "subdir", "nested", "result")
+            mbs.savefile = savefile
+            mbs.save_results()  # must not raise
+            self.assertTrue(os.path.isfile(savefile + ".qu"))
+
 
 class TestBuildZlist(unittest.TestCase):
     def test_default_zlist(self):


### PR DESCRIPTION
## Summary

- `MBSolve.save_results()` and `OBBase.mesolve()` now call `os.makedirs(dir, exist_ok=True)` before `qu.qsave()`, so saving to a nested path like `results/run1/output` no longer raises `FileNotFoundError` when the intermediate directories don't exist
- Added `TestSaveLoad.test_save_creates_missing_directory` to verify the fix

## Test plan

- [x] `uv run pytest tests/test_mb_solve.py::TestSaveLoad -q` — 3 passed
- [x] `uv run pytest -n auto -q` — 137 passed

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)