### PR TITLE
Add autodoc API reference

### DIFF
--- a/docs/api/field.rst
+++ b/docs/api/field.rst
@@ -1,0 +1,6 @@
+field
+=====
+
+.. automodule:: maxwellbloch.field
+   :members:
+   :show-inheritance:

--- a/docs/api/hyperfine.rst
+++ b/docs/api/hyperfine.rst
@@ -1,0 +1,6 @@
+hyperfine
+=========
+
+.. automodule:: maxwellbloch.hyperfine
+   :members:
+   :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,14 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 1
+
+   mb_solve
+   ob_solve
+   ob_atom
+   field
+   t_funcs
+   spectral
+   utility
+   hyperfine

--- a/docs/api/mb_solve.rst
+++ b/docs/api/mb_solve.rst
@@ -1,0 +1,6 @@
+mb_solve
+========
+
+.. automodule:: maxwellbloch.mb_solve
+   :members:
+   :show-inheritance:

--- a/docs/api/ob_atom.rst
+++ b/docs/api/ob_atom.rst
@@ -1,0 +1,6 @@
+ob_atom
+=======
+
+.. automodule:: maxwellbloch.ob_atom
+   :members:
+   :show-inheritance:

--- a/docs/api/ob_solve.rst
+++ b/docs/api/ob_solve.rst
@@ -1,0 +1,6 @@
+ob_solve
+========
+
+.. automodule:: maxwellbloch.ob_solve
+   :members:
+   :show-inheritance:

--- a/docs/api/spectral.rst
+++ b/docs/api/spectral.rst
@@ -1,0 +1,6 @@
+spectral
+========
+
+.. automodule:: maxwellbloch.spectral
+   :members:
+   :show-inheritance:

--- a/docs/api/t_funcs.rst
+++ b/docs/api/t_funcs.rst
@@ -1,0 +1,6 @@
+t_funcs
+=======
+
+.. automodule:: maxwellbloch.t_funcs
+   :members:
+   :show-inheritance:

--- a/docs/api/utility.rst
+++ b/docs/api/utility.rst
@@ -1,0 +1,6 @@
+utility
+=======
+
+.. automodule:: maxwellbloch.utility
+   :members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,24 @@ author = "Thomas P. Ogden"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["recommonmark", "sphinx_rtd_theme", "nbsphinx", "sphinx.ext.mathjax"]
+extensions = [
+    "recommonmark",
+    "sphinx_rtd_theme",
+    "nbsphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+]
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+    "show-inheritance": True,
+    "private-members": False,
+}
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,12 @@ See the Examples section below for details.
 
    support/troubleshooting
 
+.. toctree::
+   :maxdepth: 1
+   :caption: API Reference
+
+   api/index
+
 .. Indices and Tables
 .. ==================
 

--- a/src/maxwellbloch/hyperfine.py
+++ b/src/maxwellbloch/hyperfine.py
@@ -145,11 +145,11 @@ class Atom1e(_JsonMixin):
             (list): factors, length of mF_list
 
         Notes:
-        - An isotropic field is a field with equal components in all three
-            possible polarizations.
-        - Any given polarisation of the field only interacts with one of the
-            three components of the dipole moment, so it is appropriate to
-            average over the couplings (i.e. factor 1/3) rather than sum.
+            - An isotropic field is a field with equal components in all three
+              possible polarizations.
+            - Any given polarisation of the field only interacts with one of the
+              three components of the dipole moment, so it is appropriate to
+              average over the couplings (i.e. factor 1/3) rather than sum.
         """
 
         return self.get_decay_factors(F_level_idxs_a, F_level_idxs_b) / np.sqrt(3.0)
@@ -185,10 +185,10 @@ class Atom1e(_JsonMixin):
             never needs to be set, just used for testing that claim.
 
         Notes:
-        - Sum of the matrix elements from a single ground-state sublevel to the
-            levels in a particular F' energy level.
-        - The sum S_{FF'} is independent of the ground state sublevel chosen.
-        - The sum of S_{FF'} over upper F levels should be 1.
+            - Sum of the matrix elements from a single ground-state sublevel
+              to the levels in a particular F' energy level.
+            - The sum S_{FF'} is independent of the ground state sublevel chosen.
+            - The sum of S_{FF'} over upper F levels should be 1.
 
         Refs:
             [0]: https://steck.us/alkalidata/rubidium87numbers.pdf

--- a/src/maxwellbloch/ob_atom.py
+++ b/src/maxwellbloch/ob_atom.py
@@ -59,7 +59,7 @@ class OBAtom(ob_base.OBBase):
     def build_initial_state(self, initial_state: list[float] | None = None) -> qu.Qobj:
         """Build the initial density matrix for the atom.
 
-        The default is for all of the population to be in |0> <0|.
+        The default is for all of the population to be in ``|0><0|``.
 
         Args:
             rho0: a list or array of populations, length num_states.


### PR DESCRIPTION
## Summary

- Enable `sphinx.ext.autodoc`, `sphinx.ext.napoleon`, and `sphinx.ext.viewcode` in `conf.py`
- Add `docs/api/` with one RST page per public module: `mb_solve`, `ob_solve`, `ob_atom`, `field`, `t_funcs`, `spectral`, `utility`, `hyperfine`
- Wire an "API Reference" section into the main toctree
- Fix three docstring RST formatting issues surfaced by autodoc:
  - `hyperfine.py`: `Notes:` bullet continuation lines needed 2-space indent (2 docstrings)
  - `ob_atom.py`: `|0><0|` escaped as backtick-quoted inline literal to avoid RST substitution parse error

Closes #223

## Test plan

- [x] `sphinx-build -E` (full rebuild, no cache) produces zero errors
- [x] `sphinx-build -W` (warnings-as-errors) passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)