### PR TITLE
Add counter-propagating field support with depletion check

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,6 +67,7 @@ See the Examples section below for details.
    usage/structure
    usage/spectral-analysis
    usage/velocity-classes
+   usage/counter-propagating
    usage/built-in-time-functions
    usage/scripts
 

--- a/docs/usage/counter-propagating.ipynb
+++ b/docs/usage/counter-propagating.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Counter-Propagating Fields\n",
+    "\n",
+    "Many atomic physics experiments use fields that propagate in opposite directions through\n",
+    "the medium. A common example is Rydberg EIT, where a near-infrared probe and a blue\n",
+    "coupling field enter the vapour cell from opposite ends to reduce (or eliminate) the\n",
+    "Doppler broadening of the two-photon resonance.\n",
+    "\n",
+    "## Why a counter-propagating geometry changes the Doppler shift\n",
+    "\n",
+    "An atom moving with velocity $v$ along the propagation axis sees each field at a\n",
+    "Doppler-shifted frequency. For a field with wave-vector $\\mathbf{k}$:\n",
+    "\n",
+    "- **Co-propagating** ($\\mathbf{k} \\parallel \\hat{z}$): the atom sees the field\n",
+    "  blue-shifted by $kv$, so its effective one-photon detuning shifts by $+kv$.\n",
+    "- **Counter-propagating** ($\\mathbf{k} \\antiparallel \\hat{z}$): the shift is\n",
+    "  $-kv$.\n",
+    "\n",
+    "In a two-photon (Ξ or Λ) scheme, the _two-photon_ detuning is the sum of the\n",
+    "individual detunings. When both fields propagate in the same direction, the\n",
+    "two-photon detuning picks up $+kv + kv = 2kv$, and the resonance is\n",
+    "Doppler-broadened. When the fields counter-propagate with similar wavelengths, the\n",
+    "shifts partially or fully cancel, giving a narrower (Doppler-reduced or\n",
+    "Doppler-free) two-photon resonance.\n",
+    "\n",
+    "## How MaxwellBloch handles this\n",
+    "\n",
+    "MaxwellBloch propagates all fields in the $+z$ direction (it solves an\n",
+    "initial-value problem marching from $z_\\mathrm{min}$ to $z_\\mathrm{max}$). A\n",
+    "genuinely counter-propagating field would require boundary data at $z_\\mathrm{max}$\n",
+    "and backward integration, turning the problem into a boundary-value problem.\n",
+    "\n",
+    "However, when the counter-propagating field **does not deplete significantly**\n",
+    "across the cell—a valid approximation for many coupling fields in EIT\n",
+    "experiments—the forward-propagating solver is equivalent to the true\n",
+    "counter-propagating geometry. The only physical difference is the **sign of the\n",
+    "Doppler shift** each velocity class contributes to that field. MaxwellBloch exposes\n",
+    "this sign via the `counter_propagating` field attribute.\n",
+    "\n",
+    "> **Note on phrasing.** This is *not* an 'undepleted-coupling approximation' in the\n",
+    "> sense of neglecting absorption. The solver computes absorption honestly for every\n",
+    "> velocity class. The approximation is purely geometric: it exploits the spatial\n",
+    "> symmetry that holds when the counter-propagating field's intensity profile is\n",
+    "> essentially flat across the cell."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic usage: `counter_propagating`\n",
+    "\n",
+    "Set `\"counter_propagating\": true` on any field in the JSON configuration. This\n",
+    "tells MaxwellBloch to apply the Doppler shift with the opposite sign for that field,\n",
+    "while leaving the forward-propagation geometry unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mb_solve_json = \"\"\"\n",
+    "{\n",
+    "  \"atom\": {\n",
+    "    \"num_states\": 3,\n",
+    "    \"decays\": [{\"channels\": [[0, 1], [1, 2]], \"rate\": 1.0}],\n",
+    "    \"fields\": [\n",
+    "      {\n",
+    "        \"label\": \"probe\",\n",
+    "        \"coupled_levels\": [[0, 1]],\n",
+    "        \"rabi_freq\": 1.0e-3,\n",
+    "        \"rabi_freq_t_func\": \"gaussian\",\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 1.0, \"centre\": 0.0, \"fwhm\": 1.0}\n",
+    "      },\n",
+    "      {\n",
+    "        \"label\": \"coupling\",\n",
+    "        \"coupled_levels\": [[1, 2]],\n",
+    "        \"rabi_freq\": 5.0,\n",
+    "        \"rabi_freq_t_func\": \"ramp_onoff\",\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 1.0, \"fwhm\": 0.2, \"on\": -2.0, \"off\": 8.0},\n",
+    "        \"counter_propagating\": true\n",
+    "      }\n",
+    "    ]\n",
+    "  },\n",
+    "  \"t_min\": -2.0,\n",
+    "  \"t_max\": 8.0,\n",
+    "  \"t_steps\": 120,\n",
+    "  \"z_min\": 0.0,\n",
+    "  \"z_max\": 1.0,\n",
+    "  \"z_steps\": 20,\n",
+    "  \"z_steps_inner\": 2,\n",
+    "  \"interaction_strengths\": [1.0, 1.0],\n",
+    "  \"velocity_classes\": {\n",
+    "    \"thermal_width\": 5.0,\n",
+    "    \"thermal_delta_min\": -15.0,\n",
+    "    \"thermal_delta_max\": 15.0,\n",
+    "    \"thermal_delta_steps\": 10\n",
+    "  },\n",
+    "  \"savefile\": \"counter-propagating-eit\"\n",
+    "}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maxwellbloch import mb_solve\n",
+    "\n",
+    "mbs = mb_solve.MBSolve().from_json_str(mb_solve_json)\n",
+    "print(f\"Coupling field counter_propagating: {mbs.atom.fields[1].counter_propagating}\")\n",
+    "print(f\"Coupling factor_doppler_shift:      {mbs.atom.fields[1].factor_doppler_shift}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Omegas_zt, states_zt = mbs.mbsolve()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Depletion check\n",
+    "\n",
+    "After solving, MaxwellBloch automatically checks whether the counter-propagating\n",
+    "field depleted significantly across the cell. The check computes\n",
+    "\n",
+    "$$\n",
+    "\\text{depletion} = 1 - \\frac{\\max_t |\\Omega(z_\\mathrm{max}, t)|}{\\max_t |\\Omega(z_\\mathrm{min}, t)|}\n",
+    "$$\n",
+    "\n",
+    "- **< 1 %** — check passes silently. The forward-propagation result is reliable.\n",
+    "- **1 – 10 %** — a `UserWarning` is emitted. Results may still be usable but\n",
+    "  caution is advised.\n",
+    "- **> 10 %** — a `CounterPropagatingDepletionError` is raised. The approximation\n",
+    "  has broken down.\n",
+    "\n",
+    "You can suppress the check with `check_counter_prop_depletion=False` if you know\n",
+    "the depletion is acceptable for your purposes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "coupling_idx = 1  # second field\n",
+    "Omega_coupling = Omegas_zt[coupling_idx]\n",
+    "peak_in  = np.max(np.abs(Omega_coupling[0]))\n",
+    "peak_out = np.max(np.abs(Omega_coupling[-1]))\n",
+    "depletion = 1.0 - peak_out / peak_in\n",
+    "print(f\"Coupling field depletion: {depletion:.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Advanced: `factor_doppler_shift`\n",
+    "\n",
+    "For schemes where the two counter-propagating fields have **different wavelengths**\n",
+    "(e.g. a three-photon Doppler-free ladder where $k_1 \\neq k_2$), the Doppler\n",
+    "cancellation is only partial. Use `factor_doppler_shift` directly to set the\n",
+    "fractional weight:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"coupled_levels\": [[2, 3]],\n",
+    "  \"rabi_freq\": 1.5,\n",
+    "  \"factor_doppler_shift\": -0.62\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "The sign determines the direction; the magnitude scales the Doppler shift relative\n",
+    "to the thermal width unit. `factor_doppler_shift = 1.0` (the default) gives\n",
+    "standard co-propagating behaviour; `-1.0` is equivalent to\n",
+    "`counter_propagating = true`.\n",
+    "\n",
+    "> **Note on `detuning_positive`.** The `detuning_positive` flag on a field is a\n",
+    "> **separate and orthogonal** concept. It controls the sign convention for the RWA\n",
+    "> Hamiltonian based on the level ordering (used when the second coupled level sits\n",
+    "> below the first in energy, e.g. the lower leg of a Λ system). It has nothing to\n",
+    "> do with the laser k-vector direction. Both flags can be set independently."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pulse-area check\n",
+    "\n",
+    "As a sanity check, verify that the probe pulse area at the input is correct."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "probe_area_in = np.trapezoid(np.abs(Omegas_zt[0, 0, :]), mbs.tlist) / np.pi\nprint(f\"Probe area at z=z_min: {probe_area_in:.4f} π\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "1. Mohapatra, Jackson, Adams — *Coherent Optical Detection of Highly Excited\n",
+    "   Rydberg States Using Electromagnetically Induced Transparency*,\n",
+    "   PRL **98**, 113003 (2007). Example of the counter-propagating Rydberg EIT\n",
+    "   geometry this feature supports.\n",
+    "2. Adams, Pritchard, Shaffer — *Rydberg atom physics*,\n",
+    "   J. Phys. B **53**, 012002 (2020). Broader review including Doppler-free\n",
+    "   multi-photon spectroscopy."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/maxwellbloch/exceptions.py
+++ b/src/maxwellbloch/exceptions.py
@@ -1,0 +1,7 @@
+class CounterPropagatingDepletionError(RuntimeError):
+    """Raised when a counter-propagating field depletes beyond the error threshold.
+
+    The forward-propagation solver is only equivalent to true counter-propagation
+    when depletion is negligible. Pass ``check_counter_prop_depletion=False`` to
+    ``mbsolve()`` to suppress this check if you know what you are doing.
+    """

--- a/src/maxwellbloch/field.py
+++ b/src/maxwellbloch/field.py
@@ -21,6 +21,14 @@ class Field(object):
         detuning (float): detuning of the fields from resonance with the
             coupled_levels transitions.
         detuning_positive (bool): is the detuning positive?
+        counter_propagating (bool): if True, this field travels in the
+            opposite direction to the forward-propagating solver direction.
+            Sets factor_doppler_shift = -1.0. Orthogonal to detuning_positive.
+        factor_doppler_shift (float): multiplier applied to the thermal
+            detuning Delta for each velocity class. Default 1.0 (co-propagating).
+            Set to -1.0 for a counter-propagating field, or to an arbitrary
+            float for schemes where wavelength differences matter (e.g. a
+            three-photon ladder where k-vector magnitudes differ).
         rabi_freq (float): Rabi frequency of the field on the transition.
         rabi_freq_t_func (func): Time-dependency of rabi_freq as function of
             time f(t, args)
@@ -35,6 +43,8 @@ class Field(object):
         factors: list[float] | None = None,
         detuning: float = 0.0,
         detuning_positive: bool = True,
+        counter_propagating: bool = False,
+        factor_doppler_shift: float | None = None,
         rabi_freq: float = 1.0,
         rabi_freq_t_func: str | None = None,
         rabi_freq_t_args: dict[str, float] | None = None,
@@ -55,6 +65,8 @@ class Field(object):
         self.detuning = detuning
         self.detuning_positive = detuning_positive
 
+        self._build_doppler_shift(counter_propagating, factor_doppler_shift)
+
         self.rabi_freq = rabi_freq
         self.rabi_freq_t_args = rabi_freq_t_args
 
@@ -70,7 +82,11 @@ class Field(object):
             + "factors={3}, "
             + "detuning={4}, "
             + "detuning_positive={5}, "
-            "rabi_freq={6}, " + "rabi_freq_t_func={7}, " + "rabi_freq_t_args={8})"
+            + "counter_propagating={6}, "
+            + "factor_doppler_shift={7}, "
+            + "rabi_freq={8}, "
+            + "rabi_freq_t_func={9}, "
+            + "rabi_freq_t_args={10})"
         ).format(
             self.label,
             self.index,
@@ -78,10 +94,40 @@ class Field(object):
             self.factors,
             self.detuning,
             self.detuning_positive,
+            self.counter_propagating,
+            self.factor_doppler_shift,
             self.rabi_freq,
             self.rabi_freq_t_func,
             self.rabi_freq_t_args,
         )
+
+    def _build_doppler_shift(
+        self, counter_propagating: bool, factor_doppler_shift: float | None
+    ) -> None:
+        """Set counter_propagating and factor_doppler_shift with consistency check.
+
+        counter_propagating=True is sugar for factor_doppler_shift=-1.0. Setting
+        counter_propagating=True alongside an explicit positive factor_doppler_shift
+        is a conflict and raises ValueError.
+        """
+        if (
+            counter_propagating
+            and factor_doppler_shift is not None
+            and factor_doppler_shift > 0.0
+        ):
+            raise ValueError(
+                "counter_propagating=True implies factor_doppler_shift < 0, "
+                "but factor_doppler_shift={} was also supplied. "
+                "Either set counter_propagating=True (to use -1.0) or set "
+                "factor_doppler_shift directly, not both.".format(factor_doppler_shift)
+            )
+        self.counter_propagating = counter_propagating
+        if counter_propagating:
+            self.factor_doppler_shift = -1.0
+        elif factor_doppler_shift is None:
+            self.factor_doppler_shift = 1.0
+        else:
+            self.factor_doppler_shift = factor_doppler_shift
 
     def lower_levels(self) -> list[int]:
         """Return the unique lower (ground) level indices coupled by this field.
@@ -172,6 +218,8 @@ class Field(object):
             "factors": self.factors,
             "detuning": self.detuning,
             "detuning_positive": self.detuning_positive,
+            "counter_propagating": self.counter_propagating,
+            "factor_doppler_shift": self.factor_doppler_shift,
             "rabi_freq": self.rabi_freq,
             "rabi_freq_t_args": self.rabi_freq_t_args,
         }

--- a/src/maxwellbloch/mb_solve.py
+++ b/src/maxwellbloch/mb_solve.py
@@ -11,6 +11,7 @@ import numpy as np
 import qutip as qu
 
 from maxwellbloch import ob_solve, t_funcs
+from maxwellbloch.exceptions import CounterPropagatingDepletionError
 from maxwellbloch.utility import maxwell_boltzmann
 
 
@@ -286,6 +287,9 @@ class MBSolve(ob_solve.OBSolve):
         rho0: qu.Qobj | None = None,
         recalc: bool = True,
         pbar_chunk_size: int = 10,
+        check_counter_prop_depletion: bool = True,
+        depletion_warn: float = 0.01,
+        depletion_error: float = 0.10,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Solves the Maxwell-Bloch equations for the system.
 
@@ -294,6 +298,11 @@ class MBSolve(ob_solve.OBSolve):
             rho0 (Qobj): the initial density matrix state
             recalc (bool): Recalculate the solution even if a savefile exists?
             pbar_chunk_size: Every how many % should we log progress to stdout.
+            check_counter_prop_depletion: Run a post-solve depletion check on
+                any counter-propagating fields. Set False to suppress.
+            depletion_warn: Depletion fraction that triggers a UserWarning.
+            depletion_error: Depletion fraction that raises
+                CounterPropagatingDepletionError.
 
         Returns:
             self.Omegas_zt: The solved field complex Rabi frequency at each
@@ -324,6 +333,12 @@ class MBSolve(ob_solve.OBSolve):
                 self.load_results()
             except ValueError:
                 _do_solve()
+
+        if check_counter_prop_depletion:
+            self._check_counter_prop_depletion(
+                depletion_warn=depletion_warn, depletion_error=depletion_error
+            )
+
         return self.Omegas_zt, self.states_zt
 
     def mbsolve_euler(
@@ -546,9 +561,16 @@ class MBSolve(ob_solve.OBSolve):
         # The set detunings, without any thermal shifting
         fixed_detunings = self.atom.get_detunings()
         for Delta_i, Delta in enumerate(self.thermal_delta_list):
-            # print('Delta_i: {0}, Delta: {1:.2f}'.format(Delta_i, Delta))
-            # Shift each detuning by Delta.
-            self.atom.set_H_Delta([fd + Delta for fd in fixed_detunings])
+            # Shift each field's detuning by Delta scaled by that field's
+            # Doppler sign. Counter-propagating fields get factor_doppler_shift=-1.
+            self.atom.set_H_Delta(
+                [
+                    fd + Delta * field.factor_doppler_shift
+                    for fd, field in zip(
+                        fixed_detunings, self.atom.fields, strict=False
+                    )
+                ]
+            )
             # We don't want the obsolve to save.
             self.obsolve(opts=None, save=False)
             states_t_Delta[Delta_i] = self.states_t()
@@ -558,6 +580,49 @@ class MBSolve(ob_solve.OBSolve):
             states_t_Delta, axis=0, weights=self.thermal_weights
         )
         return thermal_states_t
+
+    def _check_counter_prop_depletion(
+        self,
+        depletion_warn: float = 0.01,
+        depletion_error: float = 0.10,
+    ) -> None:
+        """Check counter-propagating fields for significant depletion.
+
+        For each field with factor_doppler_shift < 0, computes the peak-based
+        depletion across the cell:
+
+            depletion = 1 - max_t|Ω(z_max, t)| / max_t|Ω(z_min, t)|
+
+        Emits a UserWarning at depletion_warn; raises
+        CounterPropagatingDepletionError at depletion_error.
+
+        The forward-propagation solver is only equivalent to true
+        counter-propagation when depletion is negligible. Results at high
+        depletion levels may be unreliable.
+        """
+        for field_idx, field in enumerate(self.atom.fields):
+            if field.factor_doppler_shift >= 0:
+                continue
+            Omega_field = self.Omegas_zt[field_idx]  # shape (z_steps+1, t_steps+1)
+            peak_zmin = np.max(np.abs(Omega_field[0]))
+            peak_zmax = np.max(np.abs(Omega_field[-1]))
+            if peak_zmin == 0.0:
+                continue
+            depletion = 1.0 - peak_zmax / peak_zmin
+            name = field.label or f"field[{field_idx}]"
+            msg = (
+                f"Counter-propagating field '{name}' depleted by {depletion:.1%} "
+                f"across the cell. The forward-propagation solver is only equivalent "
+                f"to true counter-propagation when depletion is negligible. Results "
+                f"at this depletion level may be unreliable."
+            )
+            if depletion >= depletion_error:
+                raise CounterPropagatingDepletionError(
+                    msg + " Pass check_counter_prop_depletion=False to mbsolve() to "
+                    "suppress this check."
+                )
+            elif depletion >= depletion_warn:
+                warnings.warn(msg, UserWarning, stacklevel=3)
 
     def get_json_dict(self) -> dict:
         """Return the full problem definition as a JSON-serialisable dict."""

--- a/tests/test_counter_propagating.py
+++ b/tests/test_counter_propagating.py
@@ -1,0 +1,393 @@
+"""Tests for counter-propagating field support (A0).
+
+Physics cases:
+1. Undepleted regime: depletion check passes silently.
+2. Moderately depleted regime: UserWarning emitted.
+3. Heavily depleted regime: CounterPropagatingDepletionError raised.
+4. Doppler sign correctness: counter-propagating coupling gives Doppler-free
+   two-photon resonance (narrower EIT linewidth than co-propagating).
+5. Regression: omitting new attrs gives bit-exact output vs existing fixtures.
+
+Thomas Ogden <t@ogden.eu>
+"""
+
+import unittest
+import warnings
+
+import numpy as np
+
+from maxwellbloch import mb_solve
+from maxwellbloch.exceptions import CounterPropagatingDepletionError
+from maxwellbloch.field import Field
+
+# ---------------------------------------------------------------------------
+# Field schema / init tests
+# ---------------------------------------------------------------------------
+
+
+class TestFieldCounterPropInit(unittest.TestCase):
+    def test_defaults(self):
+        """Default field has counter_propagating=False, factor_doppler_shift=1.0."""
+        f = Field(coupled_levels=[[0, 1]])
+        self.assertFalse(f.counter_propagating)
+        self.assertEqual(f.factor_doppler_shift, 1.0)
+
+    def test_counter_propagating_sets_factor(self):
+        """counter_propagating=True sets factor_doppler_shift to -1.0."""
+        f = Field(coupled_levels=[[0, 1]], counter_propagating=True)
+        self.assertTrue(f.counter_propagating)
+        self.assertEqual(f.factor_doppler_shift, -1.0)
+
+    def test_factor_doppler_shift_negative(self):
+        """factor_doppler_shift can be set to a negative float directly."""
+        f = Field(coupled_levels=[[0, 1]], factor_doppler_shift=-0.62)
+        self.assertFalse(f.counter_propagating)
+        self.assertAlmostEqual(f.factor_doppler_shift, -0.62)
+
+    def test_counter_propagating_false_with_negative_factor(self):
+        """counter_propagating=False and factor_doppler_shift=-1.0 is legal."""
+        f = Field(
+            coupled_levels=[[0, 1]],
+            counter_propagating=False,
+            factor_doppler_shift=-1.0,
+        )
+        self.assertFalse(f.counter_propagating)
+        self.assertEqual(f.factor_doppler_shift, -1.0)
+
+    def test_conflicting_flags_raise(self):
+        """counter_propagating=True with factor_doppler_shift>0 raises ValueError."""
+        with self.assertRaises(ValueError):
+            Field(
+                coupled_levels=[[0, 1]],
+                counter_propagating=True,
+                factor_doppler_shift=1.0,
+            )
+
+    def test_json_roundtrip(self):
+        """New attrs survive JSON serialisation round-trip."""
+        f = Field(
+            coupled_levels=[[0, 1]],
+            counter_propagating=True,
+            label="coupling",
+        )
+        f2 = Field.from_json_str(f.to_json_str())
+        self.assertTrue(f2.counter_propagating)
+        self.assertEqual(f2.factor_doppler_shift, -1.0)
+
+    def test_json_roundtrip_factor_only(self):
+        """factor_doppler_shift=-0.62 survives JSON round-trip."""
+        f = Field(coupled_levels=[[0, 1]], factor_doppler_shift=-0.62)
+        f2 = Field.from_json_str(f.to_json_str())
+        self.assertAlmostEqual(f2.factor_doppler_shift, -0.62)
+
+
+# ---------------------------------------------------------------------------
+# Regression: bit-exact output when new attrs are absent from JSON
+# ---------------------------------------------------------------------------
+
+# Minimal 3-level EIT config reused across depletion tests. Parameters chosen
+# so the coupling field is strong and barely depletes (OD ≈ 0.5 per unit length).
+_LADDER_BASE_JSON = """
+{
+  "atom": {
+    "num_states": 3,
+    "decays": [{"channels": [[0, 1], [1, 2]], "rate": 1.0}],
+    "fields": [
+      {
+        "label": "probe",
+        "coupled_levels": [[0, 1]],
+        "rabi_freq": 1.0,
+        "rabi_freq_t_func": "sech",
+        "rabi_freq_t_args": {"ampl": 0.5, "centre": 0.0, "width": 0.5}
+      },
+      {
+        "label": "coupling",
+        "coupled_levels": [[1, 2]],
+        "rabi_freq": 5.0,
+        "rabi_freq_t_func": "ramp_onoff",
+        "rabi_freq_t_args": {"ampl": 1.0, "fwhm": 0.2, "on": -2.0, "off": 8.0},
+        "counter_propagating": true
+      }
+    ]
+  },
+  "t_min": -2.0,
+  "t_max": 8.0,
+  "t_steps": 50,
+  "z_min": 0.0,
+  "z_max": 1.0,
+  "z_steps": 5,
+  "z_steps_inner": 2,
+  "interaction_strengths": [0.5, 0.5]
+}
+"""
+
+# Same config but without counter_propagating on the coupling. Used as the
+# regression baseline — output must be identical when factor_doppler_shift=1
+# (no velocity classes, so Doppler shift is irrelevant).
+_LADDER_NO_CP_JSON = """
+{
+  "atom": {
+    "num_states": 3,
+    "decays": [{"channels": [[0, 1], [1, 2]], "rate": 1.0}],
+    "fields": [
+      {
+        "label": "probe",
+        "coupled_levels": [[0, 1]],
+        "rabi_freq": 1.0,
+        "rabi_freq_t_func": "sech",
+        "rabi_freq_t_args": {"ampl": 0.5, "centre": 0.0, "width": 0.5}
+      },
+      {
+        "label": "coupling",
+        "coupled_levels": [[1, 2]],
+        "rabi_freq": 5.0,
+        "rabi_freq_t_func": "ramp_onoff",
+        "rabi_freq_t_args": {"ampl": 1.0, "fwhm": 0.2, "on": -2.0, "off": 8.0}
+      }
+    ]
+  },
+  "t_min": -2.0,
+  "t_max": 8.0,
+  "t_steps": 50,
+  "z_min": 0.0,
+  "z_max": 1.0,
+  "z_steps": 5,
+  "z_steps_inner": 2,
+  "interaction_strengths": [0.5, 0.5]
+}
+"""
+
+
+class TestRegression(unittest.TestCase):
+    def test_no_velocity_classes_bit_exact(self):
+        """Without velocity classes, counter_propagating has no effect on Omegas_zt.
+
+        With no Doppler broadening (no velocity_classes), the thermal_delta_list
+        contains only [0.0], so factor_doppler_shift multiplies zero — output is
+        bit-exact regardless of the flag.
+        """
+        mbs_cp = mb_solve.MBSolve.from_json_str(_LADDER_BASE_JSON)
+        mbs_no_cp = mb_solve.MBSolve.from_json_str(_LADDER_NO_CP_JSON)
+
+        mbs_cp.mbsolve(recalc=True, check_counter_prop_depletion=False)
+        mbs_no_cp.mbsolve(recalc=True, check_counter_prop_depletion=False)
+
+        np.testing.assert_array_equal(mbs_cp.Omegas_zt, mbs_no_cp.Omegas_zt)
+        np.testing.assert_array_equal(mbs_cp.states_zt, mbs_no_cp.states_zt)
+
+
+# ---------------------------------------------------------------------------
+# Depletion check tests
+# ---------------------------------------------------------------------------
+
+# Two-level absorber with a weak Gaussian probe. At high OD the probe depletes
+# substantially; at low OD it passes through. We mark the probe field as
+# counter_propagating so the depletion check fires.
+# Interaction-strength values that hit each depletion band come from numerical
+# calibration (see plans/phase-a/A0-counter-propagating-field-support.md):
+#   strength=0.003 → ~0.2%  (undepleted, < 1%)
+#   strength=0.07  → ~5.0%  (moderate,   1–10%)
+#   strength=0.5   → ~30.5% (heavy,       > 10%)
+
+
+def _two_level_absorber_json(interaction_strength: float) -> str:
+    return f"""
+{{
+  "atom": {{
+    "num_states": 2,
+    "decays": [{{"channels": [[0, 1]], "rate": 1.0}}],
+    "fields": [
+      {{
+        "label": "probe",
+        "coupled_levels": [[0, 1]],
+        "rabi_freq": 0.001,
+        "rabi_freq_t_func": "gaussian",
+        "rabi_freq_t_args": {{"ampl": 1.0, "centre": 0.0, "fwhm": 1.0}},
+        "counter_propagating": true
+      }}
+    ]
+  }},
+  "t_min": -2.0,
+  "t_max": 10.0,
+  "t_steps": 120,
+  "z_min": 0.0,
+  "z_max": 1.0,
+  "z_steps": 30,
+  "z_steps_inner": 2,
+  "interaction_strengths": [{interaction_strength}]
+}}
+"""
+
+
+class TestDepletionCheckUndepleted(unittest.TestCase):
+    def test_no_warning_at_low_od(self):
+        """Weak probe at very low OD: depletion < 1%, check passes silently."""
+        mbs = mb_solve.MBSolve.from_json_str(_two_level_absorber_json(0.003))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mbs.mbsolve(recalc=True)
+        depletion_warnings = [
+            x
+            for x in w
+            if issubclass(x.category, UserWarning)
+            and "depleted" in str(x.message).lower()
+        ]
+        self.assertEqual(len(depletion_warnings), 0)
+
+        # Confirm depletion really is < 1%
+        Omega = mbs.Omegas_zt[0]
+        peak_zmin = np.max(np.abs(Omega[0]))
+        peak_zmax = np.max(np.abs(Omega[-1]))
+        depletion = 1.0 - peak_zmax / peak_zmin
+        self.assertLess(depletion, 0.01)
+
+
+class TestDepletionCheckModerate(unittest.TestCase):
+    def test_warning_at_moderate_od(self):
+        """Probe at moderate OD: depletion between 1% and 10%, UserWarning emitted."""
+        mbs = mb_solve.MBSolve.from_json_str(_two_level_absorber_json(0.07))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mbs.mbsolve(recalc=True)
+        depletion_warnings = [
+            x
+            for x in w
+            if issubclass(x.category, UserWarning)
+            and "depleted" in str(x.message).lower()
+        ]
+        self.assertGreater(len(depletion_warnings), 0)
+        # Warning text should mention "forward-propagation"
+        self.assertIn(
+            "forward-propagation",
+            str(depletion_warnings[0].message).lower(),
+        )
+
+        # Confirm depletion is in the 1–10% band
+        Omega = mbs.Omegas_zt[0]
+        peak_zmin = np.max(np.abs(Omega[0]))
+        peak_zmax = np.max(np.abs(Omega[-1]))
+        depletion = 1.0 - peak_zmax / peak_zmin
+        self.assertGreaterEqual(depletion, 0.01)
+        self.assertLess(depletion, 0.10)
+
+
+class TestDepletionCheckHeavy(unittest.TestCase):
+    def test_error_at_high_od(self):
+        """Probe at high OD: depletion > 10%, CounterPropagatingDepletionError raised."""
+        mbs = mb_solve.MBSolve.from_json_str(_two_level_absorber_json(0.5))
+        with self.assertRaises(CounterPropagatingDepletionError):
+            mbs.mbsolve(recalc=True)
+
+    def test_suppressed_with_flag(self):
+        """check_counter_prop_depletion=False suppresses the error."""
+        mbs = mb_solve.MBSolve.from_json_str(_two_level_absorber_json(0.5))
+        # Should not raise
+        mbs.mbsolve(recalc=True, check_counter_prop_depletion=False)
+
+
+# ---------------------------------------------------------------------------
+# Doppler sign correctness
+# ---------------------------------------------------------------------------
+
+# Direct sign test using a 2-level system.
+#
+# A probe is detuned by D from the atomic resonance. A single velocity class
+# is chosen so that its Doppler shift exactly cancels the probe detuning for
+# the COUNTER-propagating case, while doubling it for the CO-propagating case.
+#
+# Convention in MBSolve: thermal_delta_list[j] = 2π * thermal_delta_value.
+# This is added directly to f.detuning, which _build_H_Delta multiplies by 2π.
+# So the resonance condition for counter-prop is:
+#     f.detuning + (-1) * 2π * delta = 0  →  delta = D / (2π)
+#
+# At delta = D/(2π) ≈ 0.159 * D:
+#   co-prop:      eff_detuning ≈ D + D = 2D  →  off resonance → low absorption
+#   counter-prop: eff_detuning ≈ D - D = 0   →  on resonance  → high absorption
+#
+# Numerically calibrated: counter-prop gives ~11x more absorption than co-prop.
+
+_DOPPLER_SIGN_D = 1.0  # probe detuning in γ units
+_DOPPLER_SIGN_DELTA = _DOPPLER_SIGN_D / (2.0 * np.pi)  # single velocity class value
+
+
+def _doppler_sign_json(counter_propagating: bool) -> str:
+    cp_str = "true" if counter_propagating else "false"
+    d = _DOPPLER_SIGN_DELTA
+    return f"""
+{{
+  "atom": {{
+    "num_states": 2,
+    "decays": [{{"channels": [[0, 1]], "rate": 1.0}}],
+    "fields": [
+      {{
+        "label": "probe",
+        "coupled_levels": [[0, 1]],
+        "detuning": {_DOPPLER_SIGN_D},
+        "rabi_freq": 0.001,
+        "rabi_freq_t_func": "gaussian",
+        "rabi_freq_t_args": {{"ampl": 1.0, "centre": 0.0, "fwhm": 1.0}},
+        "counter_propagating": {cp_str}
+      }}
+    ]
+  }},
+  "t_min": -2.0,
+  "t_max": 8.0,
+  "t_steps": 80,
+  "z_min": 0.0,
+  "z_max": 1.0,
+  "z_steps": 5,
+  "z_steps_inner": 2,
+  "interaction_strengths": [0.1],
+  "velocity_classes": {{
+    "thermal_width": 10.0,
+    "thermal_delta_min": {d},
+    "thermal_delta_max": {d},
+    "thermal_delta_steps": 0,
+    "thermal_delta_inner_min": {d},
+    "thermal_delta_inner_max": {d},
+    "thermal_delta_inner_steps": 0
+  }}
+}}
+"""
+
+
+class TestDopplerSignCorrectness(unittest.TestCase):
+    def test_counter_prop_increases_absorption_at_resonance(self):
+        """Counter-propagating flag flips the Doppler sign, bringing probe on resonance.
+
+        With probe detuning D and a single velocity class at delta = D/(2π):
+        - Co-propagating:      effective detuning = D + 2π*(D/2π) =  2D (off resonance)
+        - Counter-propagating: effective detuning = D - 2π*(D/2π) =  0  (on resonance)
+
+        Counter-propagating should therefore give significantly more absorption.
+        Numerically calibrated: counter-prop depletion / co-prop depletion ≈ 11×.
+        """
+        mbs_co = mb_solve.MBSolve.from_json_str(_doppler_sign_json(False))
+        mbs_cp = mb_solve.MBSolve.from_json_str(_doppler_sign_json(True))
+
+        mbs_co.mbsolve(recalc=True, check_counter_prop_depletion=False)
+        mbs_cp.mbsolve(recalc=True, check_counter_prop_depletion=False)
+
+        def _depletion(mbs: mb_solve.MBSolve) -> float:
+            Omega = mbs.Omegas_zt[0]
+            peak_zmin = np.max(np.abs(Omega[0]))
+            peak_zmax = np.max(np.abs(Omega[-1]))
+            return 1.0 - peak_zmax / peak_zmin
+
+        dep_co = _depletion(mbs_co)
+        dep_cp = _depletion(mbs_cp)
+
+        # Counter-prop should give substantially more absorption (at least 3×)
+        self.assertGreater(
+            dep_cp,
+            3.0 * dep_co,
+            msg=(
+                f"Counter-propagating (on resonance) depletion {dep_cp:.4%} "
+                f"should be at least 3× co-propagating (off resonance) {dep_co:.4%}. "
+                "This tests that the Doppler sign flips correctly."
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1878,7 +1878,7 @@ wheels = [
 
 [[package]]
 name = "maxwellbloch"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "qutip" },


### PR DESCRIPTION
## Summary

- Adds `counter_propagating: bool` and `factor_doppler_shift: float` per-field attributes to `Field`, giving per-field control over the sign and magnitude of the Doppler shift applied to each velocity class
- Updates the thermal detuning loop in `MBSolve._solve_and_average_over_thermal_detunings()` to multiply `Delta` by `field.factor_doppler_shift` (was always `+1`)
- Adds `_check_counter_prop_depletion()` post-solve: warns at >1% depletion, raises `CounterPropagatingDepletionError` (new `exceptions.py`) at >10%
- 13 new tests covering init semantics, JSON round-trip, regression (bit-exact output without velocity classes), all three depletion bands, and Doppler sign correctness
- New usage notebook `docs/usage/counter-propagating.ipynb` with physical motivation and depletion check documentation

## Unblocks

A10 (Rydberg EIT example), A11 (Doppler-free spectroscopy), B1/B2/B6 downstream.

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest -n auto` — 153/153 passed
- [x] `uv run sphinx-build docs docs/_build -b html` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)