### PR TITLE
Add maxwellbloch.plot submodule with core plotting primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: uv sync --extra test
+        run: uv sync --extra test --extra plot
       - name: Lint with ruff
         run: |
           uvx ruff check .

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,7 @@ See the Examples section below for details.
    usage/spectral-analysis
    usage/velocity-classes
    usage/counter-propagating
+   usage/plotting
    usage/built-in-time-functions
    usage/scripts
 

--- a/docs/usage/plotting.ipynb
+++ b/docs/usage/plotting.ipynb
@@ -1,0 +1,294 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Plotting\n",
+    "\n",
+    "`maxwellbloch.plot` provides Plotly-based visualisation primitives for\n",
+    "MBSolve and OBSolve results. Figures are interactive in the browser —\n",
+    "hover to read values, drag to zoom, click the legend to toggle traces.\n",
+    "\n",
+    "## Installation\n",
+    "\n",
+    "The plotting module requires the optional `[plot]` dependencies:\n",
+    "\n",
+    "```bash\n",
+    "pip install maxwellbloch[plot]\n",
+    "```\n",
+    "\n",
+    "or with uv:\n",
+    "\n",
+    "```bash\n",
+    "uv pip install maxwellbloch[plot]\n",
+    "```\n",
+    "\n",
+    "`kaleido` is included in `[plot]` and is required for static PNG export\n",
+    "(`fig.write_image()`). If you only need interactive figures in a notebook\n",
+    "you can install `plotly` alone.\n",
+    "\n",
+    "## Usage pattern\n",
+    "\n",
+    "All plot functions take a solved `MBSolve` instance as their first argument\n",
+    "and return a `plotly.graph_objects.Figure`. They never call `.show()`\n",
+    "internally — that is always your call:\n",
+    "\n",
+    "```python\n",
+    "from maxwellbloch import plot\n",
+    "\n",
+    "fig = plot.field_spacetime(mbs)         # returns a Figure\n",
+    "fig.show(renderer='notebook_connected') # interactive in Jupyter\n",
+    "fig.write_image('output.png')           # static PNG via kaleido\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-header",
+   "metadata": {},
+   "source": [
+    "## Setup: solve a two-level absorber\n",
+    "\n",
+    "We use a weak Gaussian probe propagating through a two-level absorber.\n",
+    "This is enough to demonstrate every primitive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maxwellbloch import mb_solve, plot\n",
+    "\n",
+    "mb_solve_json = \"\"\"\n",
+    "{\n",
+    "  \"atom\": {\n",
+    "    \"num_states\": 2,\n",
+    "    \"decays\": [{\"channels\": [[0, 1]], \"rate\": 1.0}],\n",
+    "    \"fields\": [\n",
+    "      {\n",
+    "        \"label\": \"probe\",\n",
+    "        \"coupled_levels\": [[0, 1]],\n",
+    "        \"rabi_freq\": 0.01,\n",
+    "        \"rabi_freq_t_func\": \"gaussian\",\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 1.0, \"centre\": 0.0, \"fwhm\": 1.0}\n",
+    "      }\n",
+    "    ]\n",
+    "  },\n",
+    "  \"t_min\": -3.0,\n",
+    "  \"t_max\": 6.0,\n",
+    "  \"t_steps\": 120,\n",
+    "  \"z_min\": 0.0,\n",
+    "  \"z_max\": 1.0,\n",
+    "  \"z_steps\": 20,\n",
+    "  \"z_steps_inner\": 2,\n",
+    "  \"interaction_strengths\": [2.0],\n",
+    "  \"savefile\": \"plotting-two-level\"\n",
+    "}\n",
+    "\"\"\"\n",
+    "\n",
+    "mbs = mb_solve.MBSolve.from_json_str(mb_solve_json)\n",
+    "Omegas_zt, states_zt = mbs.mbsolve()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "spacetime-header",
+   "metadata": {},
+   "source": [
+    "## `field_spacetime` — space-time heatmap of |Ω(z, t)|\n",
+    "\n",
+    "The most common view: the full propagation in one figure.\n",
+    "Hover over any pixel to read the exact (z, t, |Ω|) values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "spacetime",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.field_spacetime(mbs)\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "envelope-header",
+   "metadata": {},
+   "source": [
+    "## `field_envelope` — pulse shape at fixed z\n",
+    "\n",
+    "Compare the input pulse (z = z_min) to the output pulse (z = z_max).\n",
+    "The probe is absorbed as it propagates through the medium."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "envelope",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.field_envelope(mbs, z_indices=[0, -1])\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pulse-area-header",
+   "metadata": {},
+   "source": [
+    "## `pulse_area` — area theorem\n",
+    "\n",
+    "The pulse area $\\mathcal{A} = \\int |\\Omega(z,t)|\\, dt / \\pi$ decreases\n",
+    "from the input value as the probe is absorbed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pulse-area",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.pulse_area(mbs)\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "spectrum-header",
+   "metadata": {},
+   "source": [
+    "## `spectrum` — frequency-domain absorption\n",
+    "\n",
+    "Computes the absorption spectrum via Fourier transform of the time-domain\n",
+    "field. This works in the linear (weak-field) regime: for strong fields the\n",
+    "result is the nonlinear transmission, not the susceptibility.\n",
+    "\n",
+    "Pass `show_dispersion=True` to add the dispersive component on a secondary\n",
+    "axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "spectrum",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.spectrum(mbs, show_dispersion=True)\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "population-header",
+   "metadata": {},
+   "source": [
+    "## `population` — state populations vs time\n",
+    "\n",
+    "The diagonal elements $\\rho_{ii}(t)$ of the density matrix at a fixed\n",
+    "z position. The probe drives population from |0⟩ to |1⟩ and back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "population",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.population(mbs, z_idx=0)\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pop-spacetime-header",
+   "metadata": {},
+   "source": [
+    "## `population_spacetime` — population heatmap\n",
+    "\n",
+    "Like `field_spacetime` but for a density-matrix diagonal element.\n",
+    "Useful for visualising population inversion, storage, and retrieval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pop-spacetime",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.population_spacetime(mbs, state_idx=1)\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "coherence-header",
+   "metadata": {},
+   "source": [
+    "## `coherence` — off-diagonal density matrix elements\n",
+    "\n",
+    "Plot $|\\rho_{01}(t)|$, $\\mathrm{Re}(\\rho_{01})$, or $\\mathrm{Im}(\\rho_{01})$\n",
+    "at a fixed z. The coherence is proportional to the macroscopic polarisation\n",
+    "of the medium and drives the field evolution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "coherence",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.coherence(mbs, 0, 1, z_idx=0, component='abs')\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "static-export-header",
+   "metadata": {},
+   "source": [
+    "## Static PNG export\n",
+    "\n",
+    "Any figure can be saved as a static PNG using `fig.write_image()`. This\n",
+    "requires `kaleido` (included in `maxwellbloch[plot]`).\n",
+    "\n",
+    "```python\n",
+    "fig = plot.field_spacetime(mbs)\n",
+    "fig.write_image('field_spacetime.png', scale=2)  # scale=2 for high-DPI\n",
+    "```\n",
+    "\n",
+    "SVG and PDF are also supported:\n",
+    "\n",
+    "```python\n",
+    "fig.write_image('field_spacetime.svg')\n",
+    "fig.write_image('field_spacetime.pdf')\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ docs = [
     "plotly>=5.18",
     "kaleido>=0.2",
 ]
-dev = ["maxwellbloch[test,docs]", "ruff", "twine", "bump-my-version"]
+plot = ["plotly>=5.18", "kaleido>=0.2"]
+dev = ["maxwellbloch[test,docs,plot]", "ruff", "twine", "bump-my-version"]
 
 [tool.bumpversion]
 current_version = "0.10.0"

--- a/src/maxwellbloch/plot/__init__.py
+++ b/src/maxwellbloch/plot/__init__.py
@@ -1,0 +1,44 @@
+"""MaxwellBloch plotting module (Plotly-based).
+
+Install the optional plotting dependencies with::
+
+    pip install maxwellbloch[plot]
+
+All primitives return a ``plotly.graph_objects.Figure``; they never call
+``.show()`` internally. Use ``fig.show(renderer='notebook_connected')``
+in Jupyter notebooks for interactive output, or ``fig.write_image(path)``
+for static PNG export (requires kaleido).
+
+Example::
+
+    from maxwellbloch import mb_solve, plot
+
+    mbs = mb_solve.MBSolve.from_json_str(...)
+    mbs.mbsolve()
+
+    fig = plot.field_spacetime(mbs)
+    fig.show(renderer='notebook_connected')
+"""
+
+try:
+    import plotly  # noqa: F401
+except ImportError as e:
+    raise ImportError(
+        "The maxwellbloch.plot module requires plotly. "
+        "Install it with: pip install maxwellbloch[plot]"
+    ) from e
+
+from maxwellbloch.plot.fields import field_envelope, field_spacetime, pulse_area
+from maxwellbloch.plot.spectra import spectrum, spectrum_overlay
+from maxwellbloch.plot.states import coherence, population, population_spacetime
+
+__all__ = [
+    "field_spacetime",
+    "field_envelope",
+    "pulse_area",
+    "spectrum",
+    "spectrum_overlay",
+    "population",
+    "population_spacetime",
+    "coherence",
+]

--- a/src/maxwellbloch/plot/fields.py
+++ b/src/maxwellbloch/plot/fields.py
@@ -1,0 +1,139 @@
+"""Field plot primitives: field_spacetime, field_envelope, pulse_area."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import plotly.graph_objects as go
+
+from maxwellbloch.plot import theme as _theme  # noqa: F401 — registers template
+from maxwellbloch.plot.utils import field_label, omega_abs, pulse_area_z
+
+if TYPE_CHECKING:
+    from maxwellbloch.mb_solve import MBSolve
+
+_TEMPLATE = "maxwellbloch"
+
+
+def field_spacetime(
+    mbs: MBSolve,
+    field_idx: int = 0,
+    *,
+    colorscale: str = "Viridis",
+    width: int = 700,
+    height: int = 400,
+) -> go.Figure:
+    """Heatmap of |Ω(z, t)| for *field_idx*.
+
+    Args:
+        mbs: A solved MBSolve instance.
+        field_idx: Index of the field to plot.
+        colorscale: Plotly colorscale name.
+        width: Figure width in pixels.
+        height: Figure height in pixels.
+
+    Returns:
+        plotly Figure — call ``.show()`` or ``.write_image()`` on it.
+    """
+    Omega = omega_abs(mbs, field_idx)
+    label = field_label(mbs, field_idx)
+
+    fig = go.Figure(
+        data=go.Heatmap(
+            z=Omega,
+            x=mbs.tlist,
+            y=mbs.zlist,
+            colorscale=colorscale,
+            colorbar=dict(title="|Ω| (γ)"),
+        ),
+        layout=go.Layout(
+            title=f"|Ω(z, t)| — {label}",
+            xaxis_title="t (γ⁻¹)",
+            yaxis_title="z",
+            width=width,
+            height=height,
+            template=_TEMPLATE,
+        ),
+    )
+    return fig
+
+
+def field_envelope(
+    mbs: MBSolve,
+    field_idx: int = 0,
+    *,
+    z_indices: int | list[int] | None = None,
+    width: int = 700,
+    height: int = 400,
+) -> go.Figure:
+    """Line plot of |Ω(t)| at one or more fixed z positions.
+
+    Args:
+        mbs: A solved MBSolve instance.
+        field_idx: Index of the field to plot.
+        z_indices: z-step index or list of indices. Defaults to first and last.
+        width: Figure width in pixels.
+        height: Figure height in pixels.
+
+    Returns:
+        plotly Figure.
+    """
+    Omega = omega_abs(mbs, field_idx)
+    label = field_label(mbs, field_idx)
+
+    if z_indices is None:
+        z_indices = [0, -1]
+    if isinstance(z_indices, int):
+        z_indices = [z_indices]
+
+    fig = go.Figure(
+        layout=go.Layout(
+            title=f"|Ω(t)| — {label}",
+            xaxis_title="t (γ⁻¹)",
+            yaxis_title="|Ω| (γ)",
+            width=width,
+            height=height,
+            template=_TEMPLATE,
+        )
+    )
+    for zi in z_indices:
+        z_val = mbs.zlist[zi]
+        fig.add_trace(
+            go.Scatter(x=mbs.tlist, y=Omega[zi], mode="lines", name=f"z = {z_val:.2f}")
+        )
+    return fig
+
+
+def pulse_area(
+    mbs: MBSolve,
+    field_idx: int = 0,
+    *,
+    width: int = 700,
+    height: int = 400,
+) -> go.Figure:
+    """Line plot of pulse area ∫|Ω|dt / π vs z.
+
+    Args:
+        mbs: A solved MBSolve instance.
+        field_idx: Index of the field to plot.
+        width: Figure width in pixels.
+        height: Figure height in pixels.
+
+    Returns:
+        plotly Figure.
+    """
+    area = pulse_area_z(mbs, field_idx)
+    label = field_label(mbs, field_idx)
+
+    fig = go.Figure(
+        data=go.Scatter(x=mbs.zlist, y=area, mode="lines+markers"),
+        layout=go.Layout(
+            title=f"Pulse area vs z — {label}",
+            xaxis_title="z",
+            yaxis_title="area (π)",
+            width=width,
+            height=height,
+            template=_TEMPLATE,
+        ),
+    )
+    return fig

--- a/src/maxwellbloch/plot/spectra.py
+++ b/src/maxwellbloch/plot/spectra.py
@@ -1,0 +1,124 @@
+"""Spectral plot primitives: spectrum, spectrum_overlay."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import plotly.graph_objects as go
+
+from maxwellbloch import spectral
+from maxwellbloch.plot import theme as _theme  # noqa: F401 — registers template
+
+if TYPE_CHECKING:
+    from maxwellbloch.mb_solve import MBSolve
+
+_TEMPLATE = "maxwellbloch"
+
+
+def spectrum(
+    mbs: MBSolve,
+    field_idx: int = 0,
+    *,
+    z_idx: int = -1,
+    show_dispersion: bool = False,
+    width: int = 700,
+    height: int = 400,
+) -> go.Figure:
+    """Absorption (and optionally dispersion) spectrum via Fourier transform.
+
+    Uses the Fourier transform of the time-domain field to extract the
+    frequency-domain absorption at z position *z_idx*.
+
+    Args:
+        mbs: A solved MBSolve instance. The probe field should be a weak
+            pulse (so the linear-response approximation holds).
+        field_idx: Index of the probe field.
+        z_idx: z-step index at which to compute absorption.
+        show_dispersion: If True, also plot the dispersion on a secondary axis.
+        width: Figure width in pixels.
+        height: Figure height in pixels.
+
+    Returns:
+        plotly Figure.
+    """
+    freqs = spectral.freq_list(mbs)
+    absorp = spectral.absorption(mbs, field_idx, z_idx=z_idx)
+
+    label = mbs.atom.fields[field_idx].label or f"field {field_idx}"
+
+    fig = go.Figure(
+        layout=go.Layout(
+            title=f"Absorption spectrum — {label}",
+            xaxis_title="frequency (γ)",
+            yaxis_title="absorption (a.u.)",
+            width=width,
+            height=height,
+            template=_TEMPLATE,
+        )
+    )
+    fig.add_trace(go.Scatter(x=freqs, y=absorp, mode="lines", name="absorption"))
+
+    if show_dispersion:
+        disp = spectral.dispersion(mbs, field_idx, z_idx=z_idx)
+        fig.add_trace(
+            go.Scatter(
+                x=freqs,
+                y=disp,
+                mode="lines",
+                name="dispersion",
+                yaxis="y2",
+            )
+        )
+        fig.update_layout(
+            yaxis2=dict(
+                title="dispersion (a.u.)",
+                overlaying="y",
+                side="right",
+                showgrid=False,
+            )
+        )
+
+    return fig
+
+
+def spectrum_overlay(
+    mbs_list: list[MBSolve],
+    field_idx: int = 0,
+    *,
+    z_idx: int = -1,
+    labels: list[str] | None = None,
+    width: int = 900,
+    height: int = 400,
+) -> go.Figure:
+    """Overlay absorption spectra from multiple MBSolve results.
+
+    Args:
+        mbs_list: List of solved MBSolve instances.
+        field_idx: Field index to plot in each.
+        z_idx: z-step index for absorption.
+        labels: Trace labels, one per element of mbs_list.
+        width: Figure width in pixels.
+        height: Figure height in pixels.
+
+    Returns:
+        plotly Figure.
+    """
+    if labels is None:
+        labels = [f"run {i}" for i in range(len(mbs_list))]
+
+    fig = go.Figure(
+        layout=go.Layout(
+            title="Absorption spectra",
+            xaxis_title="frequency (γ)",
+            yaxis_title="absorption (a.u.)",
+            width=width,
+            height=height,
+            template=_TEMPLATE,
+        )
+    )
+    for mbs, lbl in zip(mbs_list, labels, strict=False):
+        freqs = spectral.freq_list(mbs)
+        absorp = spectral.absorption(mbs, field_idx, z_idx=z_idx)
+        fig.add_trace(go.Scatter(x=freqs, y=absorp, mode="lines", name=lbl))
+
+    return fig

--- a/src/maxwellbloch/plot/states.py
+++ b/src/maxwellbloch/plot/states.py
@@ -1,0 +1,159 @@
+"""State plot primitives: population, population_spacetime, coherence."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import plotly.graph_objects as go
+
+from maxwellbloch.plot import theme as _theme  # noqa: F401 — registers template
+
+if TYPE_CHECKING:
+    from maxwellbloch.mb_solve import MBSolve
+
+_TEMPLATE = "maxwellbloch"
+
+
+def population(
+    mbs: MBSolve,
+    state_indices: int | list[int] | None = None,
+    *,
+    z_idx: int = 0,
+    width: int = 700,
+    height: int = 400,
+) -> go.Figure:
+    """Line plot of populations ρ_ii(t) at a fixed z position.
+
+    Args:
+        mbs: A solved MBSolve instance.
+        state_indices: State index or list of indices. Defaults to all states.
+        z_idx: z-step index.
+        width: Figure width in pixels.
+        height: Figure height in pixels.
+
+    Returns:
+        plotly Figure.
+    """
+    num_states = mbs.atom.num_states
+    if state_indices is None:
+        state_indices = list(range(num_states))
+    if isinstance(state_indices, int):
+        state_indices = [state_indices]
+
+    fig = go.Figure(
+        layout=go.Layout(
+            title=f"Population vs t (z = {mbs.zlist[z_idx]:.2f})",
+            xaxis_title="t (γ⁻¹)",
+            yaxis_title="population",
+            width=width,
+            height=height,
+            template=_TEMPLATE,
+        )
+    )
+    for si in state_indices:
+        rho_ii = mbs.states_zt[z_idx, :, si, si].real
+        fig.add_trace(go.Scatter(x=mbs.tlist, y=rho_ii, mode="lines", name=f"|{si}⟩"))
+    return fig
+
+
+def population_spacetime(
+    mbs: MBSolve,
+    state_idx: int = 0,
+    *,
+    colorscale: str = "Viridis",
+    zmin: float | None = None,
+    zmax: float | None = None,
+    width: int = 700,
+    height: int = 400,
+) -> go.Figure:
+    """Heatmap of population ρ_ii(z, t) for a single state.
+
+    Args:
+        mbs: A solved MBSolve instance.
+        state_idx: State index.
+        colorscale: Plotly colorscale name.
+        zmin: Colorbar minimum. Defaults to auto (data minimum).
+        zmax: Colorbar maximum. Defaults to auto (data maximum). Pass
+            ``zmin=0, zmax=1`` to compare populations on a common scale.
+        width: Figure width in pixels.
+        height: Figure height in pixels.
+
+    Returns:
+        plotly Figure.
+    """
+    rho_ii = mbs.states_zt[:, :, state_idx, state_idx].real
+
+    fig = go.Figure(
+        data=go.Heatmap(
+            z=rho_ii,
+            x=mbs.tlist,
+            y=mbs.zlist,
+            colorscale=colorscale,
+            colorbar=dict(title=f"ρ_{state_idx}{state_idx}"),
+            zmin=zmin,
+            zmax=zmax,
+        ),
+        layout=go.Layout(
+            title=f"Population ρ_{state_idx}{state_idx}(z, t)",
+            xaxis_title="t (γ⁻¹)",
+            yaxis_title="z",
+            width=width,
+            height=height,
+            template=_TEMPLATE,
+        ),
+    )
+    return fig
+
+
+def coherence(
+    mbs: MBSolve,
+    i: int,
+    j: int,
+    *,
+    z_idx: int = 0,
+    component: str = "abs",
+    width: int = 700,
+    height: int = 400,
+) -> go.Figure:
+    """Line plot of coherence ρ_ij(t) at a fixed z position.
+
+    Args:
+        mbs: A solved MBSolve instance.
+        i: Row index of the density matrix element.
+        j: Column index of the density matrix element.
+        z_idx: z-step index.
+        component: One of ``"abs"``, ``"real"``, or ``"imag"``.
+        width: Figure width in pixels.
+        height: Figure height in pixels.
+
+    Returns:
+        plotly Figure.
+    """
+    rho_ij = mbs.states_zt[z_idx, :, i, j]
+    if component == "abs":
+        y = np.abs(rho_ij)
+        ylabel = f"|ρ_{i}{j}|"
+    elif component == "real":
+        y = rho_ij.real
+        ylabel = f"Re(ρ_{i}{j})"
+    elif component == "imag":
+        y = rho_ij.imag
+        ylabel = f"Im(ρ_{i}{j})"
+    else:
+        raise ValueError(
+            f"component must be 'abs', 'real', or 'imag', got {component!r}"
+        )
+
+    fig = go.Figure(
+        data=go.Scatter(x=mbs.tlist, y=y, mode="lines"),
+        layout=go.Layout(
+            title=f"{ylabel}(t) at z = {mbs.zlist[z_idx]:.2f}",
+            xaxis_title="t (γ⁻¹)",
+            yaxis_title=ylabel,
+            width=width,
+            height=height,
+            template=_TEMPLATE,
+        ),
+    )
+    return fig

--- a/src/maxwellbloch/plot/theme.py
+++ b/src/maxwellbloch/plot/theme.py
@@ -1,0 +1,52 @@
+"""MaxwellBloch Plotly theme template."""
+
+import plotly.graph_objects as go
+import plotly.io as pio
+
+_CATEGORICAL_COLORS = [
+    "#4477AA",  # blue
+    "#EE6677",  # rose
+    "#228833",  # green
+    "#CCBB44",  # yellow
+    "#66CCEE",  # cyan
+    "#AA3377",  # purple
+    "#BBBBBB",  # grey
+]
+
+_TEMPLATE = go.layout.Template(
+    layout=go.Layout(
+        font=dict(family="sans-serif", size=13),
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        colorway=_CATEGORICAL_COLORS,
+        xaxis=dict(
+            showgrid=True,
+            gridcolor="#e0e0e0",
+            zeroline=True,
+            zerolinecolor="#aaaaaa",
+            zerolinewidth=1,
+            ticks="inside",
+            showline=True,
+            linecolor="#888888",
+            mirror=False,
+        ),
+        yaxis=dict(
+            showgrid=True,
+            gridcolor="#e0e0e0",
+            zeroline=True,
+            zerolinecolor="#aaaaaa",
+            zerolinewidth=1,
+            ticks="inside",
+            showline=True,
+            linecolor="#888888",
+            mirror=False,
+        ),
+        colorscale=dict(sequential="Viridis", diverging="RdBu"),
+        legend=dict(
+            bgcolor="rgba(255,255,255,0.8)", bordercolor="#cccccc", borderwidth=1
+        ),
+        margin=dict(l=60, r=20, t=50, b=60),
+    )
+)
+
+pio.templates["maxwellbloch"] = _TEMPLATE

--- a/src/maxwellbloch/plot/utils.py
+++ b/src/maxwellbloch/plot/utils.py
@@ -1,0 +1,35 @@
+"""Array extraction and unit-conversion helpers for plot primitives."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from maxwellbloch.mb_solve import MBSolve
+
+
+def omega_abs(mbs: MBSolve, field_idx: int = 0) -> np.ndarray:
+    """Return |Ω(z, t)| for *field_idx*.
+
+    Returns:
+        Array of shape (z_steps+1, t_steps+1).
+    """
+    return np.abs(mbs.Omegas_zt[field_idx])
+
+
+def pulse_area_z(mbs: MBSolve, field_idx: int = 0) -> np.ndarray:
+    """Return the pulse area ∫|Ω(z,t)|dt / π vs z.
+
+    Returns:
+        Array of shape (z_steps+1,) in units of π.
+    """
+    Omega = omega_abs(mbs, field_idx)
+    return np.trapezoid(Omega, mbs.tlist, axis=1) / np.pi
+
+
+def field_label(mbs: MBSolve, field_idx: int = 0) -> str:
+    """Return a display label for a field, falling back to its index."""
+    label = mbs.atom.fields[field_idx].label
+    return label if label else f"field {field_idx}"

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,271 @@
+"""Smoke tests for maxwellbloch.plot primitives.
+
+Tests verify that every public primitive:
+  - returns a plotly Figure
+  - has the expected trace type
+  - has layout attributes set (title, axis labels)
+
+No visual correctness is checked — that belongs in the usage notebook.
+"""
+
+import unittest
+
+import numpy as np
+import plotly.graph_objects as go
+
+from maxwellbloch import mb_solve, plot
+
+# Minimal two-level two-field config used by all field/state tests.
+_TWO_LEVEL_JSON = """
+{
+  "atom": {
+    "num_states": 2,
+    "decays": [{"channels": [[0, 1]], "rate": 1.0}],
+    "fields": [
+      {
+        "label": "probe",
+        "coupled_levels": [[0, 1]],
+        "rabi_freq": 0.01,
+        "rabi_freq_t_func": "gaussian",
+        "rabi_freq_t_args": {"ampl": 1.0, "centre": 0.0, "fwhm": 1.0}
+      }
+    ]
+  },
+  "t_min": -2.0,
+  "t_max": 4.0,
+  "t_steps": 60,
+  "z_min": 0.0,
+  "z_max": 1.0,
+  "z_steps": 5,
+  "z_steps_inner": 2,
+  "interaction_strengths": [0.1]
+}
+"""
+
+# Three-level ladder — two fields, for spectrum_overlay test.
+_THREE_LEVEL_JSON = """
+{
+  "atom": {
+    "num_states": 3,
+    "decays": [{"channels": [[0, 1], [1, 2]], "rate": 1.0}],
+    "fields": [
+      {
+        "label": "probe",
+        "coupled_levels": [[0, 1]],
+        "rabi_freq": 0.01,
+        "rabi_freq_t_func": "gaussian",
+        "rabi_freq_t_args": {"ampl": 1.0, "centre": 0.0, "fwhm": 1.0}
+      },
+      {
+        "label": "coupling",
+        "coupled_levels": [[1, 2]],
+        "rabi_freq": 5.0,
+        "rabi_freq_t_func": "ramp_onoff",
+        "rabi_freq_t_args": {"ampl": 1.0, "fwhm": 0.2, "on": -2.0, "off": 4.0}
+      }
+    ]
+  },
+  "t_min": -2.0,
+  "t_max": 4.0,
+  "t_steps": 60,
+  "z_min": 0.0,
+  "z_max": 1.0,
+  "z_steps": 5,
+  "z_steps_inner": 2,
+  "interaction_strengths": [0.1, 0.1]
+}
+"""
+
+
+def _solve_two_level():
+    mbs = mb_solve.MBSolve.from_json_str(_TWO_LEVEL_JSON)
+    mbs.mbsolve(recalc=True)
+    return mbs
+
+
+def _solve_three_level():
+    mbs = mb_solve.MBSolve.from_json_str(_THREE_LEVEL_JSON)
+    mbs.mbsolve(recalc=True)
+    return mbs
+
+
+# Shared solved instances (module-level to avoid re-solving per test).
+_MBS2 = None
+_MBS3 = None
+
+
+def _get_mbs2():
+    global _MBS2
+    if _MBS2 is None:
+        _MBS2 = _solve_two_level()
+    return _MBS2
+
+
+def _get_mbs3():
+    global _MBS3
+    if _MBS3 is None:
+        _MBS3 = _solve_three_level()
+    return _MBS3
+
+
+class TestFieldSpacetime(unittest.TestCase):
+    def test_returns_figure(self):
+        fig = plot.field_spacetime(_get_mbs2())
+        self.assertIsInstance(fig, go.Figure)
+
+    def test_has_heatmap_trace(self):
+        fig = plot.field_spacetime(_get_mbs2())
+        self.assertIsInstance(fig.data[0], go.Heatmap)
+
+    def test_heatmap_shape(self):
+        mbs = _get_mbs2()
+        fig = plot.field_spacetime(mbs)
+        z_vals = fig.data[0].z
+        self.assertEqual(np.array(z_vals).shape[0], len(mbs.zlist))
+
+    def test_title_contains_field_label(self):
+        fig = plot.field_spacetime(_get_mbs2())
+        self.assertIn("probe", fig.layout.title.text)
+
+    def test_axes_labelled(self):
+        fig = plot.field_spacetime(_get_mbs2())
+        self.assertIn("t", fig.layout.xaxis.title.text)
+        self.assertIn("z", fig.layout.yaxis.title.text)
+
+    def test_custom_colorscale(self):
+        fig_v = plot.field_spacetime(_get_mbs2(), colorscale="Viridis")
+        fig_c = plot.field_spacetime(_get_mbs2(), colorscale="Cividis")
+        # Plotly resolves names to tuples; they should differ between scales
+        self.assertNotEqual(fig_v.data[0].colorscale, fig_c.data[0].colorscale)
+
+
+class TestFieldEnvelope(unittest.TestCase):
+    def test_returns_figure(self):
+        fig = plot.field_envelope(_get_mbs2())
+        self.assertIsInstance(fig, go.Figure)
+
+    def test_default_two_traces(self):
+        fig = plot.field_envelope(_get_mbs2())
+        self.assertEqual(len(fig.data), 2)
+
+    def test_single_z_index(self):
+        fig = plot.field_envelope(_get_mbs2(), z_indices=0)
+        self.assertEqual(len(fig.data), 1)
+
+    def test_trace_length_matches_tlist(self):
+        mbs = _get_mbs2()
+        fig = plot.field_envelope(mbs, z_indices=0)
+        self.assertEqual(len(fig.data[0].x), len(mbs.tlist))
+
+
+class TestPulseArea(unittest.TestCase):
+    def test_returns_figure(self):
+        fig = plot.pulse_area(_get_mbs2())
+        self.assertIsInstance(fig, go.Figure)
+
+    def test_has_scatter_trace(self):
+        fig = plot.pulse_area(_get_mbs2())
+        self.assertIsInstance(fig.data[0], go.Scatter)
+
+    def test_trace_length_matches_zlist(self):
+        mbs = _get_mbs2()
+        fig = plot.pulse_area(mbs)
+        self.assertEqual(len(fig.data[0].x), len(mbs.zlist))
+
+    def test_area_decreases_for_absorber(self):
+        mbs = _get_mbs2()
+        fig = plot.pulse_area(mbs)
+        areas = fig.data[0].y
+        # Probe loses energy to absorber — area should decrease z_min → z_max
+        self.assertGreater(areas[0], areas[-1])
+
+
+class TestSpectrum(unittest.TestCase):
+    def test_returns_figure(self):
+        fig = plot.spectrum(_get_mbs2())
+        self.assertIsInstance(fig, go.Figure)
+
+    def test_has_scatter_trace(self):
+        fig = plot.spectrum(_get_mbs2())
+        self.assertIsInstance(fig.data[0], go.Scatter)
+
+    def test_with_dispersion(self):
+        fig = plot.spectrum(_get_mbs2(), show_dispersion=True)
+        self.assertEqual(len(fig.data), 2)
+
+    def test_freq_axis_length(self):
+        mbs = _get_mbs2()
+        fig = plot.spectrum(mbs)
+        self.assertEqual(len(fig.data[0].x), len(mbs.tlist))
+
+
+class TestSpectrumOverlay(unittest.TestCase):
+    def test_returns_figure(self):
+        mbs = _get_mbs2()
+        fig = plot.spectrum_overlay([mbs, mbs], labels=["a", "b"])
+        self.assertIsInstance(fig, go.Figure)
+
+    def test_trace_count(self):
+        mbs = _get_mbs2()
+        fig = plot.spectrum_overlay([mbs, mbs])
+        self.assertEqual(len(fig.data), 2)
+
+
+class TestPopulation(unittest.TestCase):
+    def test_returns_figure(self):
+        fig = plot.population(_get_mbs2())
+        self.assertIsInstance(fig, go.Figure)
+
+    def test_default_all_states(self):
+        mbs = _get_mbs2()
+        fig = plot.population(mbs)
+        self.assertEqual(len(fig.data), mbs.atom.num_states)
+
+    def test_single_state(self):
+        fig = plot.population(_get_mbs2(), state_indices=0)
+        self.assertEqual(len(fig.data), 1)
+
+    def test_populations_sum_to_one(self):
+        mbs = _get_mbs2()
+        fig = plot.population(mbs)
+        total = sum(np.array(t.y) for t in fig.data)
+        np.testing.assert_allclose(total, 1.0, atol=1e-6)
+
+
+class TestPopulationSpacetime(unittest.TestCase):
+    def test_returns_figure(self):
+        fig = plot.population_spacetime(_get_mbs2(), state_idx=0)
+        self.assertIsInstance(fig, go.Figure)
+
+    def test_has_heatmap_trace(self):
+        fig = plot.population_spacetime(_get_mbs2(), state_idx=0)
+        self.assertIsInstance(fig.data[0], go.Heatmap)
+
+    def test_colorbar_range_default_auto(self):
+        fig = plot.population_spacetime(_get_mbs2(), state_idx=0)
+        self.assertIsNone(fig.data[0].zmin)
+        self.assertIsNone(fig.data[0].zmax)
+
+    def test_colorbar_range_explicit(self):
+        fig = plot.population_spacetime(_get_mbs2(), state_idx=0, zmin=0.0, zmax=1.0)
+        self.assertEqual(fig.data[0].zmin, 0.0)
+        self.assertEqual(fig.data[0].zmax, 1.0)
+
+
+class TestCoherence(unittest.TestCase):
+    def test_returns_figure(self):
+        fig = plot.coherence(_get_mbs2(), 0, 1)
+        self.assertIsInstance(fig, go.Figure)
+
+    def test_abs_component(self):
+        mbs = _get_mbs2()
+        fig = plot.coherence(mbs, 0, 1, component="abs")
+        self.assertTrue(np.all(np.array(fig.data[0].y) >= 0))
+
+    def test_invalid_component_raises(self):
+        with self.assertRaises(ValueError):
+            plot.coherence(_get_mbs2(), 0, 1, component="phase")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -10,6 +10,10 @@ No visual correctness is checked — that belongs in the usage notebook.
 
 import unittest
 
+import pytest
+
+pytest.importorskip("plotly", reason="plotly not installed; install maxwellbloch[plot]")
+
 import numpy as np
 import plotly.graph_objects as go
 

--- a/uv.lock
+++ b/uv.lock
@@ -1955,6 +1955,10 @@ docs = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-rtd-theme" },
 ]
+plot = [
+    { name = "kaleido" },
+    { name = "plotly" },
+]
 test = [
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1971,10 +1975,12 @@ requires-dist = [
     { name = "bump-my-version", marker = "extra == 'dev'" },
     { name = "jupyter", marker = "extra == 'docs'" },
     { name = "kaleido", marker = "extra == 'docs'", specifier = ">=0.2" },
+    { name = "kaleido", marker = "extra == 'plot'", specifier = ">=0.2" },
     { name = "matplotlib", marker = "extra == 'docs'" },
-    { name = "maxwellbloch", extras = ["test", "docs"], marker = "extra == 'dev'" },
+    { name = "maxwellbloch", extras = ["test", "docs", "plot"], marker = "extra == 'dev'" },
     { name = "nbsphinx", marker = "extra == 'docs'" },
     { name = "plotly", marker = "extra == 'docs'", specifier = ">=5.18" },
+    { name = "plotly", marker = "extra == 'plot'", specifier = ">=5.18" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "pytest-xdist", marker = "extra == 'test'" },
@@ -1986,7 +1992,7 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'" },
     { name = "twine", marker = "extra == 'dev'" },
 ]
-provides-extras = ["test", "docs", "dev"]
+provides-extras = ["test", "docs", "plot", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest-benchmark", specifier = ">=5.2.3" }]


### PR DESCRIPTION
## Summary

- New `maxwellbloch.plot` subpackage with a Plotly-based house theme and eight public primitives covering fields, spectra, and density-matrix states
- All functions return `plotly.graph_objects.Figure` and never call `.show()` internally — the caller decides how to render (interactive notebook, static PNG, HTML file)
- Rendering path: interactive HTML via `fig.show(renderer='notebook_connected')` as the default, confirmed working through nbsphinx in the C5 spike (PR #257)
- New `[plot]` optional extra (`plotly>=5.18`, `kaleido>=0.2`) — solver works without it

## Primitives

| Function | Description |
|---|---|
| `plot.field_spacetime` | Heatmap of \|Ω(z, t)\| |
| `plot.field_envelope` | \|Ω(t)\| at fixed z positions |
| `plot.pulse_area` | ∫\|Ω\|dt/π vs z |
| `plot.spectrum` | Absorption (+ dispersion) via FFT |
| `plot.spectrum_overlay` | Multiple spectra on shared axes |
| `plot.population` | ρ_ii(t) at fixed z |
| `plot.population_spacetime` | Heatmap of ρ_ii(z, t), auto-scaled colorbar |
| `plot.coherence` | \|ρ_ij\|, Re, or Im at fixed z |

## Files

- `src/maxwellbloch/plot/` — six module files (`__init__`, `theme`, `utils`, `fields`, `spectra`, `states`)
- `tests/test_plot.py` — 31 smoke tests
- `docs/usage/plotting.ipynb` — interactive usage walkthrough (all primitives demonstrated on a two-level absorber)

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest -n auto` — 183/183 passed
- [x] `uv run sphinx-build docs docs/_build -b html` — clean, plotting page renders with interactive figures

🤖 Generated with [Claude Code](https://claude.com/claude-code)