### PR TITLE
A3: adiabatons in Λ system (Grobe–Hioe–Eberly)

### DIFF
--- a/docs/examples/mbs-lambda-adiabatons.ipynb
+++ b/docs/examples/mbs-lambda-adiabatons.ipynb
@@ -1,0 +1,422 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Λ-Type Three-Level: Adiabatons\n",
+    "\n",
+    "When two strong fields co-propagate through a three-level Λ medium and the\n",
+    "coupling field precedes the probe (**counterintuitive ordering**), the atomic\n",
+    "population is transferred from one ground state to the other without ever\n",
+    "significantly occupying the excited state. The fields reshape themselves\n",
+    "during propagation until they converge on self-consistent **adiabaton**\n",
+    "solutions — pulses that maintain the adiabatic dark-state condition at every\n",
+    "point in the medium.\n",
+    "\n",
+    "## Level structure\n",
+    "\n",
+    "```\n",
+    "         |1⟩ ──────────────── (excited)\n",
+    "        /    \\\n",
+    "   Ω_p /      \\ Ω_c\n",
+    "      /        \\     γ₁₀ = γ₁₂ = 1.0\n",
+    "    |0⟩        |2⟩  (ground states)\n",
+    "```\n",
+    "\n",
+    "## Physics\n",
+    "\n",
+    "The dark eigenstate of the Λ Hamiltonian is\n",
+    "\n",
+    "$$\n",
+    "|D\\rangle = \\cos\\theta\\,|0\\rangle - \\sin\\theta\\,|2\\rangle,\n",
+    "\\qquad\n",
+    "\\theta(z,t) = \\arctan\\!\\left(\\frac{\\Omega_p(z,t)}{\\Omega_c(z,t)}\\right)\n",
+    "$$\n",
+    "\n",
+    "When the mixing angle $\\theta$ varies **slowly** compared to the adiabatic\n",
+    "gap $\\sqrt{\\Omega_p^2 + \\Omega_c^2}$, atoms initially in $|D\\rangle$ stay\n",
+    "there as the pulses pass. If $\\Omega_c \\gg \\Omega_p$ initially\n",
+    "($\\theta \\approx 0$, all population in $|0\\rangle$) and $\\Omega_p \\gg \\Omega_c$\n",
+    "finally ($\\theta \\approx \\pi/2$, all population in $|2\\rangle$), complete\n",
+    "ground-state population transfer occurs with the excited state remaining\n",
+    "**dark** throughout.\n",
+    "\n",
+    "During propagation, the Maxwell equations force the fields to reshape until\n",
+    "both carry the same temporal envelope — the **adiabaton** shape —\n",
+    "differing only in amplitude (Grobe, Hioe, Eberly, PRL 1994).\n",
+    "\n",
+    "## Parameters\n",
+    "\n",
+    "| Quantity | Value | Notes |\n",
+    "|---|---|---|\n",
+    "| $\\Omega_p^{(0)}$ | $5\\,\\gamma$ | sech, strong field |\n",
+    "| $\\Omega_c^{(0)}$ | $5\\,\\gamma$ | sech, counterintuitive (arrives first) |\n",
+    "| Pulse width | $T = 2/\\gamma$ | comparable to $\\gamma^{-1}$ |\n",
+    "| OD | $\\approx 3\\times 2 = 6$ | interaction\\_strengths × num\\_states |\n",
+    "| Doppler | none | pure coherent effect |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from maxwellbloch import mb_solve, plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "coprop-section",
+   "metadata": {},
+   "source": [
+    "## Intuitive ordering: probe first\n",
+    "\n",
+    "With the probe arriving before the coupling field, the atoms are first\n",
+    "driven by the probe alone — into a strongly absorbing two-level\n",
+    "configuration. The coupling field arrives too late to establish a dark\n",
+    "state before the probe is absorbed. Both fields are attenuated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "solve-intuitive",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mb_solve_json_intuitive = \"\"\"\n",
+    "{\n",
+    "  \"atom\": {\n",
+    "    \"num_states\": 3,\n",
+    "    \"decays\": [\n",
+    "      {\"channels\": [[0, 1]], \"rate\": 1.0},\n",
+    "      {\"channels\": [[1, 2]], \"rate\": 1.0}\n",
+    "    ],\n",
+    "    \"fields\": [\n",
+    "      {\n",
+    "        \"label\": \"probe\",\n",
+    "        \"coupled_levels\": [[0, 1]],\n",
+    "        \"detuning\": 0.0,\n",
+    "        \"detuning_positive\": true,\n",
+    "        \"rabi_freq\": 5.0,\n",
+    "        \"rabi_freq_t_func\": \"sech\",\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": -2.0, \"width\": 2.0}\n",
+    "      },\n",
+    "      {\n",
+    "        \"label\": \"coupling\",\n",
+    "        \"coupled_levels\": [[1, 2]],\n",
+    "        \"detuning\": 0.0,\n",
+    "        \"detuning_positive\": false,\n",
+    "        \"rabi_freq\": 5.0,\n",
+    "        \"rabi_freq_t_func\": \"sech\",\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": 2.0, \"width\": 2.0}\n",
+    "      }\n",
+    "    ]\n",
+    "  },\n",
+    "  \"t_min\": -10.0,\n",
+    "  \"t_max\": 10.0,\n",
+    "  \"t_steps\": 200,\n",
+    "  \"z_min\": 0.0,\n",
+    "  \"z_max\": 1.0,\n",
+    "  \"z_steps\": 20,\n",
+    "  \"z_steps_inner\": 2,\n",
+    "  \"interaction_strengths\": [3.0, 3.0],\n",
+    "  \"savefile\": \"mbs-lambda-adiabatons-intuitive\"\n",
+    "}\n",
+    "\"\"\"\n",
+    "\n",
+    "mbs_int = mb_solve.MBSolve().from_json_str(mb_solve_json_intuitive)\n",
+    "mbs_int.mbsolve(recalc=False)\n",
+    "print(\"Done\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "counter-section",
+   "metadata": {},
+   "source": [
+    "## Counterintuitive ordering: coupling first (adiabaton)\n",
+    "\n",
+    "With the coupling field arriving **before** the probe, atoms are first\n",
+    "prepared with $\\Omega_c \\gg \\Omega_p$, placing the dark state near $|0\\rangle$.\n",
+    "As the probe pulse builds and the coupling fades, the dark state smoothly\n",
+    "rotates to $|2\\rangle$, transferring population adiabatically. The excited\n",
+    "state remains nearly unpopulated throughout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "solve-counter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mb_solve_json_counter = \"\"\"\n",
+    "{\n",
+    "  \"atom\": {\n",
+    "    \"num_states\": 3,\n",
+    "    \"decays\": [\n",
+    "      {\"channels\": [[0, 1]], \"rate\": 1.0},\n",
+    "      {\"channels\": [[1, 2]], \"rate\": 1.0}\n",
+    "    ],\n",
+    "    \"fields\": [\n",
+    "      {\n",
+    "        \"label\": \"probe\",\n",
+    "        \"coupled_levels\": [[0, 1]],\n",
+    "        \"detuning\": 0.0,\n",
+    "        \"detuning_positive\": true,\n",
+    "        \"rabi_freq\": 5.0,\n",
+    "        \"rabi_freq_t_func\": \"sech\",\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": 2.0, \"width\": 2.0}\n",
+    "      },\n",
+    "      {\n",
+    "        \"label\": \"coupling\",\n",
+    "        \"coupled_levels\": [[1, 2]],\n",
+    "        \"detuning\": 0.0,\n",
+    "        \"detuning_positive\": false,\n",
+    "        \"rabi_freq\": 5.0,\n",
+    "        \"rabi_freq_t_func\": \"sech\",\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": -2.0, \"width\": 2.0}\n",
+    "      }\n",
+    "    ]\n",
+    "  },\n",
+    "  \"t_min\": -10.0,\n",
+    "  \"t_max\": 10.0,\n",
+    "  \"t_steps\": 200,\n",
+    "  \"z_min\": 0.0,\n",
+    "  \"z_max\": 1.0,\n",
+    "  \"z_steps\": 20,\n",
+    "  \"z_steps_inner\": 2,\n",
+    "  \"interaction_strengths\": [3.0, 3.0],\n",
+    "  \"savefile\": \"mbs-lambda-adiabatons-counter\"\n",
+    "}\n",
+    "\"\"\"\n",
+    "\n",
+    "mbs_ctr = mb_solve.MBSolve().from_json_str(mb_solve_json_counter)\n",
+    "mbs_ctr.mbsolve(recalc=False)\n",
+    "print(\"Done\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "probe-field-section",
+   "metadata": {},
+   "source": [
+    "## Probe field: intuitive vs counterintuitive\n",
+    "\n",
+    "The space-time plots show the strikingly different fate of the probe field\n",
+    "in each geometry. In the intuitive case the probe is strongly absorbed.\n",
+    "In the counterintuitive case the probe propagates with little loss because\n",
+    "the atoms are kept dark."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot-probe-int",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.field_spacetime(mbs_int, field_idx=0)\n",
+    "fig.update_layout(title=\"Probe |Ω_p(z, t)| — intuitive ordering (probe first)\")\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot-probe-ctr",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.field_spacetime(mbs_ctr, field_idx=0)\n",
+    "fig.update_layout(title=\"Probe |Ω_p(z, t)| — counterintuitive ordering (adiabaton)\")\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "coupling-field-section",
+   "metadata": {},
+   "source": [
+    "## Coupling field: reshaping into the adiabaton\n",
+    "\n",
+    "Both fields reshape during propagation. In the counterintuitive case they\n",
+    "converge on the same temporal envelope — the adiabaton."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot-coupling-ctr",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.field_spacetime(mbs_ctr, field_idx=1)\n",
+    "fig.update_layout(title=\"Coupling |Ω_c(z, t)| — counterintuitive ordering (adiabaton)\")\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "field-envelope-section",
+   "metadata": {},
+   "source": [
+    "## Field envelopes at input and output\n",
+    "\n",
+    "Comparing the field envelope at $z = z_\\mathrm{min}$ (input) and\n",
+    "$z = z_\\mathrm{max}$ (output) shows how the two fields reshape to share\n",
+    "the same profile in the counterintuitive case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot-envelopes",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.graph_objects as go\n",
+    "from maxwellbloch.plot import theme  # ensures template is registered\n",
+    "\n",
+    "t = mbs_ctr.tlist\n",
+    "\n",
+    "fig = go.Figure(layout=go.Layout(\n",
+    "    title=\"Adiabaton: field envelopes at input and output\",\n",
+    "    xaxis_title=\"time (γ⁻¹)\",\n",
+    "    yaxis_title=\"Ω (γ)\",\n",
+    "    template=\"maxwellbloch\",\n",
+    "))\n",
+    "\n",
+    "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[0, 0, :]),  name=\"probe in\",    line=dict(dash=\"solid\")))\n",
+    "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[0, -1, :]), name=\"probe out\",   line=dict(dash=\"dash\")))\n",
+    "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[1, 0, :]),  name=\"coupling in\",  line=dict(dash=\"solid\")))\n",
+    "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[1, -1, :]), name=\"coupling out\", line=dict(dash=\"dash\")))\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "population-section",
+   "metadata": {},
+   "source": [
+    "## Population dynamics\n",
+    "\n",
+    "In the counterintuitive (adiabaton) case the excited state $|1\\rangle$\n",
+    "stays near zero throughout, while population is completely transferred from\n",
+    "$|0\\rangle$ to $|2\\rangle$. Compare with the intuitive case where\n",
+    "$\\rho_{11}$ peaks strongly and transfer is incomplete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot-pop-ctr",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.population(mbs_ctr, state_indices=[0, 1, 2], z_idx=0)\n",
+    "fig.update_layout(title=\"Population at z = z_min — counterintuitive ordering (adiabaton)\")\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot-pop-int",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.population(mbs_int, state_indices=[0, 1, 2], z_idx=0)\n",
+    "fig.update_layout(title=\"Population at z = z_min — intuitive ordering (no adiabaton)\")\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mixing-angle-section",
+   "metadata": {},
+   "source": [
+    "## Mixing angle evolution\n",
+    "\n",
+    "The mixing angle $\\theta(z, t) = \\arctan(\\Omega_p / \\Omega_c)$ at the\n",
+    "input face shows how the dark state rotates from $|0\\rangle$ to $|2\\rangle$\n",
+    "as the pulse sequence passes through."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot-mixing-angle",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Omega_p_in = abs(mbs_ctr.Omegas_zt[0, 0, :])\n",
+    "Omega_c_in = abs(mbs_ctr.Omegas_zt[1, 0, :])\n",
+    "# Avoid division by zero\n",
+    "theta = np.where(Omega_c_in > 0.01, np.arctan2(Omega_p_in, Omega_c_in), np.nan)\n",
+    "\n",
+    "fig = go.Figure(layout=go.Layout(\n",
+    "    title=\"Mixing angle θ(t) at z = z_min\",\n",
+    "    xaxis_title=\"time (γ⁻¹)\",\n",
+    "    yaxis_title=\"θ (rad)\",\n",
+    "    template=\"maxwellbloch\",\n",
+    "))\n",
+    "fig.add_trace(go.Scatter(x=t, y=theta, mode=\"lines\", name=\"θ = arctan(Ω_p / Ω_c)\"))\n",
+    "fig.update_layout(yaxis=dict(tickvals=[0, np.pi/4, np.pi/2],\n",
+    "                              ticktext=[\"0\", \"π/4\", \"π/2\"]))\n",
+    "fig.show(renderer='notebook_connected')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "- **Intuitive ordering (probe first):** atoms encounter the probe before\n",
+    "  the dark state is established → strong absorption, high $\\rho_{11}$,\n",
+    "  incomplete transfer.\n",
+    "- **Counterintuitive ordering (coupling first):** dark state\n",
+    "  adiabatically follows the mixing angle from $\\theta = 0$ to\n",
+    "  $\\theta = \\pi/2$, transferring all population $|0\\rangle \\to |2\\rangle$\n",
+    "  while $\\rho_{11} \\approx 0$ throughout. Both fields reshape into the\n",
+    "  **adiabaton** solution.\n",
+    "\n",
+    "Adiabatons are the propagating, adiabatic analog of STIRAP in\n",
+    "single-atom physics: the medium self-consistently maintains the adiabatic\n",
+    "condition as the pulses travel.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "1. R. Grobe, F. T. Hioe, J. H. Eberly, *Formation of Shape-Preserving\n",
+    "   Pulses in a Nonlinear Adiabatically Integrable System*,\n",
+    "   PRL **73**, 3183 (1994). Prediction of adiabatons.\n",
+    "2. A. Rahman, J. H. Eberly, *Theory of adiabatons in coherent optical\n",
+    "   pulse propagation*, PRA **58**, R805 (1998). Analytic structure.\n",
+    "3. K. Bergmann, H. Theuer, B. W. Shore, *Coherent population transfer\n",
+    "   among quantum states of atoms and molecules*, Rev. Mod. Phys. **70**,\n",
+    "   1003 (1998). STIRAP review — the single-atom counterpart."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/three-level.rst
+++ b/docs/examples/three-level.rst
@@ -14,6 +14,7 @@
    mbs-lambda-weak-pulse-cloud-atoms-with-coupling
    mbs-lambda-weak-pulse-cloud-atoms-with-coupling-store
    mbs-lambda-cpt
+   mbs-lambda-adiabatons
 
 ********************
   V Configuration


### PR DESCRIPTION
## Summary

- Adds `docs/examples/mbs-lambda-adiabatons.ipynb`: pedagogical adiabaton example for a Λ system
- Two MBSolve runs: **intuitive ordering** (probe arrives first → strong absorption) vs **counterintuitive ordering** (coupling first → dark-state adiabatic following, near-zero excited-state population)
- Shows field space-time plots, field envelopes at input/output (adiabaton reshaping), population dynamics, and mixing-angle evolution θ(t) = arctan(Ω_p/Ω_c)
- Updates `docs/examples/three-level.rst` Λ section

## Physics

The dark eigenstate |D⟩ = cos θ |0⟩ − sin θ |2⟩ adiabatically follows the mixing angle as the counterintuitive pulse sequence passes. Complete population transfer |0⟩ → |2⟩ with ρ₁₁ ≈ 0 — the propagating analog of STIRAP. Both fields reshape into the self-consistent adiabaton solution (Grobe, Hioe, Eberly, PRL 1994).

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest -n auto` — 184 passed
- [x] `uv run sphinx-build docs docs/_build -b html` — build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)