### PR TITLE
fix(A3): fix adiabaton pulse overlap — centres ±2→±1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,16 @@ format_check:
 
 # Docs ------------------------------------------------------------------------
 
+# Incremental build — Sphinx skips unchanged source files (fast for development).
+# If a notebook's .ipynb source has changed, Sphinx will re-execute it.
 docs_html:
 	uv run sphinx-build docs docs/_build -b html
+
+# Full rebuild — clears the Sphinx environment cache (-E) so every source file
+# is re-read and every notebook is re-executed. Use this when .qu files are
+# stale but the .ipynb source is unchanged, or after a code change outside notebooks.
+docs_rebuild:
+	uv run sphinx-build -E docs docs/_build -b html
 
 docs_serve: docs_html
 	uv run python -m http.server 8000 --directory docs/_build
@@ -35,7 +43,7 @@ docs_serve: docs_html
 dist:
 	uv build
 
-.PHONY: dist
+.PHONY: dist docs_html docs_rebuild docs_serve clean_docs
 
 # Release (bump version, commit, tag — then push to trigger CI publish) ------
 # Usage: make bump_patch / bump_minor / bump_major

--- a/docs/examples/mbs-lambda-adiabatons.ipynb
+++ b/docs/examples/mbs-lambda-adiabatons.ipynb
@@ -47,14 +47,23 @@
     "both carry the same temporal envelope — the **adiabaton** shape —\n",
     "differing only in amplitude (Grobe, Hioe, Eberly, PRL 1994).\n",
     "\n",
+    "## Key requirement: substantial pulse overlap\n",
+    "\n",
+    "For the dark state to be maintained the two fields must be present\n",
+    "simultaneously. If the coupling and probe are separated by much more than\n",
+    "their temporal width, the coupling is absorbed before the probe arrives\n",
+    "and no dark state forms. Here the pulses are offset by only $\\pm 1\\,\\gamma^{-1}$\n",
+    "with width $T = 2\\,\\gamma^{-1}$, giving ~85% normalised overlap.\n",
+    "\n",
     "## Parameters\n",
     "\n",
     "| Quantity | Value | Notes |\n",
     "|---|---|---|\n",
-    "| $\\Omega_p^{(0)}$ | $5\\,\\gamma$ | sech, strong field |\n",
-    "| $\\Omega_c^{(0)}$ | $5\\,\\gamma$ | sech, counterintuitive (arrives first) |\n",
-    "| Pulse width | $T = 2/\\gamma$ | comparable to $\\gamma^{-1}$ |\n",
-    "| OD | $\\approx 3\\times 2 = 6$ | interaction\\_strengths × num\\_states |\n",
+    "| $\\Omega_p^{(0)}$ | $5\\,\\gamma$ | sech, centred at $t = +1\\,\\gamma^{-1}$ |\n",
+    "| $\\Omega_c^{(0)}$ | $5\\,\\gamma$ | sech, centred at $t = -1\\,\\gamma^{-1}$ (arrives first) |\n",
+    "| Pulse width | $T = 2\\,\\gamma^{-1}$ | sech half-width |\n",
+    "| Pulse overlap | ~85% | normalised $\\int\\Omega_p\\Omega_c\\,dt$ |\n",
+    "| OD | $\\sim 6$ | interaction\\_strengths × z\\_max × 2 |\n",
     "| Doppler | none | pure coherent effect |"
    ]
   },
@@ -76,10 +85,11 @@
    "source": [
     "## Intuitive ordering: probe first\n",
     "\n",
-    "With the probe arriving before the coupling field, the atoms are first\n",
-    "driven by the probe alone — into a strongly absorbing two-level\n",
-    "configuration. The coupling field arrives too late to establish a dark\n",
-    "state before the probe is absorbed. Both fields are attenuated."
+    "With the probe arriving before the coupling field, the atoms encounter\n",
+    "the probe before any dark state is established. The probe drives\n",
+    "population into the excited state and is strongly absorbed. The coupling\n",
+    "field arrives later but by then the medium has already scattered.\n",
+    "No adiabaton forms."
    ]
   },
   {
@@ -105,7 +115,7 @@
     "        \"detuning_positive\": true,\n",
     "        \"rabi_freq\": 5.0,\n",
     "        \"rabi_freq_t_func\": \"sech\",\n",
-    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": -2.0, \"width\": 2.0}\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": -1.0, \"width\": 2.0}\n",
     "      },\n",
     "      {\n",
     "        \"label\": \"coupling\",\n",
@@ -114,12 +124,12 @@
     "        \"detuning_positive\": false,\n",
     "        \"rabi_freq\": 5.0,\n",
     "        \"rabi_freq_t_func\": \"sech\",\n",
-    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": 2.0, \"width\": 2.0}\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": 1.0, \"width\": 2.0}\n",
     "      }\n",
     "    ]\n",
     "  },\n",
-    "  \"t_min\": -10.0,\n",
-    "  \"t_max\": 10.0,\n",
+    "  \"t_min\": -8.0,\n",
+    "  \"t_max\": 8.0,\n",
     "  \"t_steps\": 200,\n",
     "  \"z_min\": 0.0,\n",
     "  \"z_max\": 1.0,\n",
@@ -142,11 +152,13 @@
    "source": [
     "## Counterintuitive ordering: coupling first (adiabaton)\n",
     "\n",
-    "With the coupling field arriving **before** the probe, atoms are first\n",
-    "prepared with $\\Omega_c \\gg \\Omega_p$, placing the dark state near $|0\\rangle$.\n",
-    "As the probe pulse builds and the coupling fades, the dark state smoothly\n",
-    "rotates to $|2\\rangle$, transferring population adiabatically. The excited\n",
-    "state remains nearly unpopulated throughout."
+    "With the coupling field centred at $t = -1\\,\\gamma^{-1}$ and the probe\n",
+    "at $t = +1\\,\\gamma^{-1}$, both pulses overlap substantially while the\n",
+    "coupling still leads. This maintains $\\Omega_c \\geq \\Omega_p$ at early\n",
+    "times ($\\theta \\approx 0$, dark state $\\approx |0\\rangle$) and\n",
+    "$\\Omega_p \\geq \\Omega_c$ at late times ($\\theta \\approx \\pi/2$, dark\n",
+    "state $\\approx |2\\rangle$). Population transfers adiabatically from\n",
+    "$|0\\rangle$ to $|2\\rangle$ with the excited state remaining dark."
    ]
   },
   {
@@ -172,7 +184,7 @@
     "        \"detuning_positive\": true,\n",
     "        \"rabi_freq\": 5.0,\n",
     "        \"rabi_freq_t_func\": \"sech\",\n",
-    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": 2.0, \"width\": 2.0}\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": 1.0, \"width\": 2.0}\n",
     "      },\n",
     "      {\n",
     "        \"label\": \"coupling\",\n",
@@ -181,12 +193,12 @@
     "        \"detuning_positive\": false,\n",
     "        \"rabi_freq\": 5.0,\n",
     "        \"rabi_freq_t_func\": \"sech\",\n",
-    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": -2.0, \"width\": 2.0}\n",
+    "        \"rabi_freq_t_args\": {\"ampl\": 5.0, \"centre\": -1.0, \"width\": 2.0}\n",
     "      }\n",
     "    ]\n",
     "  },\n",
-    "  \"t_min\": -10.0,\n",
-    "  \"t_max\": 10.0,\n",
+    "  \"t_min\": -8.0,\n",
+    "  \"t_max\": 8.0,\n",
     "  \"t_steps\": 200,\n",
     "  \"z_min\": 0.0,\n",
     "  \"z_max\": 1.0,\n",
@@ -209,10 +221,9 @@
    "source": [
     "## Probe field: intuitive vs counterintuitive\n",
     "\n",
-    "The space-time plots show the strikingly different fate of the probe field\n",
-    "in each geometry. In the intuitive case the probe is strongly absorbed.\n",
-    "In the counterintuitive case the probe propagates with little loss because\n",
-    "the atoms are kept dark."
+    "In the intuitive case the probe is strongly absorbed as it enters an\n",
+    "un-prepared medium. In the counterintuitive case both fields propagate\n",
+    "with little attenuation because the atoms are kept dark throughout."
    ]
   },
   {
@@ -246,7 +257,7 @@
    "source": [
     "## Coupling field: reshaping into the adiabaton\n",
     "\n",
-    "Both fields reshape during propagation. In the counterintuitive case they\n",
+    "Both fields reshape as they propagate. In the counterintuitive case they\n",
     "converge on the same temporal envelope — the adiabaton."
    ]
   },
@@ -269,9 +280,11 @@
    "source": [
     "## Field envelopes at input and output\n",
     "\n",
-    "Comparing the field envelope at $z = z_\\mathrm{min}$ (input) and\n",
-    "$z = z_\\mathrm{max}$ (output) shows how the two fields reshape to share\n",
-    "the same profile in the counterintuitive case."
+    "Comparing $|\\Omega(t)|$ at the input face ($z = z_\\mathrm{min}$) and\n",
+    "output face ($z = z_\\mathrm{max}$) shows the adiabaton reshaping: both\n",
+    "fields exit with a similar envelope, shifted toward a common shape.\n",
+    "In the counterintuitive case neither field is strongly absorbed — contrast\n",
+    "with the intuitive ordering where the probe is greatly attenuated."
    ]
   },
   {
@@ -292,9 +305,8 @@
     "    yaxis_title=\"Ω (γ)\",\n",
     "    template=\"maxwellbloch\",\n",
     "))\n",
-    "\n",
-    "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[0, 0, :]),  name=\"probe in\",    line=dict(dash=\"solid\")))\n",
-    "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[0, -1, :]), name=\"probe out\",   line=dict(dash=\"dash\")))\n",
+    "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[0, 0, :]),  name=\"probe in\",     line=dict(dash=\"solid\")))\n",
+    "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[0, -1, :]), name=\"probe out\",    line=dict(dash=\"dash\")))\n",
     "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[1, 0, :]),  name=\"coupling in\",  line=dict(dash=\"solid\")))\n",
     "fig.add_trace(go.Scatter(x=t, y=abs(mbs_ctr.Omegas_zt[1, -1, :]), name=\"coupling out\", line=dict(dash=\"dash\")))\n",
     "fig.show(renderer='notebook_connected')"
@@ -308,8 +320,8 @@
     "## Population dynamics\n",
     "\n",
     "In the counterintuitive (adiabaton) case the excited state $|1\\rangle$\n",
-    "stays near zero throughout, while population is completely transferred from\n",
-    "$|0\\rangle$ to $|2\\rangle$. Compare with the intuitive case where\n",
+    "stays near zero throughout, while population is completely transferred\n",
+    "from $|0\\rangle$ to $|2\\rangle$. Compare with the intuitive case where\n",
     "$\\rho_{11}$ peaks strongly and transfer is incomplete."
    ]
   },
@@ -345,8 +357,9 @@
     "## Mixing angle evolution\n",
     "\n",
     "The mixing angle $\\theta(z, t) = \\arctan(\\Omega_p / \\Omega_c)$ at the\n",
-    "input face shows how the dark state rotates from $|0\\rangle$ to $|2\\rangle$\n",
-    "as the pulse sequence passes through."
+    "input face rotates smoothly from $0$ (coupling dominates, dark state\n",
+    "$\\approx |0\\rangle$) to $\\pi/2$ (probe dominates, dark state\n",
+    "$\\approx |2\\rangle$) as the pulse sequence passes."
    ]
   },
   {
@@ -358,8 +371,9 @@
    "source": [
     "Omega_p_in = abs(mbs_ctr.Omegas_zt[0, 0, :])\n",
     "Omega_c_in = abs(mbs_ctr.Omegas_zt[1, 0, :])\n",
-    "# Avoid division by zero\n",
-    "theta = np.where(Omega_c_in > 0.01, np.arctan2(Omega_p_in, Omega_c_in), np.nan)\n",
+    "# Only compute where the fields are appreciable\n",
+    "mask = (Omega_p_in + Omega_c_in) > 0.5\n",
+    "theta = np.where(mask, np.arctan2(Omega_p_in, Omega_c_in), np.nan)\n",
     "\n",
     "fig = go.Figure(layout=go.Layout(\n",
     "    title=\"Mixing angle θ(t) at z = z_min\",\n",
@@ -380,14 +394,17 @@
    "source": [
     "## Summary\n",
     "\n",
-    "- **Intuitive ordering (probe first):** atoms encounter the probe before\n",
-    "  the dark state is established → strong absorption, high $\\rho_{11}$,\n",
-    "  incomplete transfer.\n",
-    "- **Counterintuitive ordering (coupling first):** dark state\n",
-    "  adiabatically follows the mixing angle from $\\theta = 0$ to\n",
-    "  $\\theta = \\pi/2$, transferring all population $|0\\rangle \\to |2\\rangle$\n",
-    "  while $\\rho_{11} \\approx 0$ throughout. Both fields reshape into the\n",
-    "  **adiabaton** solution.\n",
+    "- **Intuitive ordering (probe first):** the probe arrives before the dark\n",
+    "  state is established → strong absorption, high $\\rho_{11}$, incomplete\n",
+    "  population transfer.\n",
+    "- **Counterintuitive ordering (coupling first, overlapping):** the\n",
+    "  dark state adiabatically follows $\\theta$ from $0$ to $\\pi/2$,\n",
+    "  transferring all population $|0\\rangle \\to |2\\rangle$ while\n",
+    "  $\\rho_{11} \\approx 0$ throughout. Both fields reshape into the\n",
+    "  **adiabaton** solution — neither is strongly absorbed.\n",
+    "- The overlap of the two pulses is essential: if they are separated by\n",
+    "  much more than the pulse width, the coupling is absorbed before the\n",
+    "  probe arrives and the dark state never forms.\n",
     "\n",
     "Adiabatons are the propagating, adiabatic analog of STIRAP in\n",
     "single-atom physics: the medium self-consistently maintains the adiabatic\n",


### PR DESCRIPTION
## Problem

The original parameters placed the probe and coupling centres at ±2 with width=2, giving only 55% normalised overlap. The coupling arrived, found no dark state partner, got absorbed, and disappeared at the output. The \"field envelopes at input and output\" plot showed coupling out ≈ 0 — this is Beer-Lambert absorption, not an adiabaton.

## Fix

Reduce pulse centres from ±2 to ±1 (width unchanged at 2), giving ~85% overlap. Both fields are now substantially present simultaneously, the adiabatic dark-state condition is maintained throughout the pulse, and both fields survive at the output converging on the adiabaton shape.

Also:
- Updates narrative to explicitly state the overlap requirement (the key physics the original missed)
- Adjusts t_min/t_max from ±10 to ±8 to match the tighter pulse window
- Improves mixing-angle mask: `(Ω_p + Ω_c) > 0.5` instead of `Ω_c > 0.01`

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest -n auto` — 184 passed
- [x] `uv run sphinx-build docs docs/_build -b html` — build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)