### PR TITLE
refactor: remove remaining in-code TODO comments

### DIFF
--- a/src/maxwellbloch/field.py
+++ b/src/maxwellbloch/field.py
@@ -48,7 +48,7 @@ class Field(object):
         self.label = label
         self.index = index
 
-        self.coupled_levels = coupled_levels  # TODO should I convert to array?
+        self.coupled_levels = coupled_levels
 
         self._build_factors(factors)
 

--- a/src/maxwellbloch/ob_atom.py
+++ b/src/maxwellbloch/ob_atom.py
@@ -203,15 +203,9 @@ class OBAtom(ob_base.OBBase):
         Hamiltonian.
         """
 
-        # TODO(#159): Need to build_rabi_freq_t_func and build_rabi_freq_t_args
-        # here somehow to add the field_idxs? NO, I think just pass in the
-        # indexes in add_field and build_fields.
-
         self.H_Omega_list = []
         for f in self.fields:
             H_Omega = qu.Qobj(np.zeros([self.num_states, self.num_states]))
-            # TODO: I think this will be better if the sigmas and factors
-            # are turned into Qu objects first, and avoid the loop(s).
             for c_i, c in enumerate(f.coupled_levels):
                 H_Omega += (
                     self.sigma(a=c[0], b=c[1]) + self.sigma(a=c[1], b=c[0])


### PR DESCRIPTION
## Summary

- `field.py`: note that `coupled_levels` stays as a list (JSON serialisation requirement)
- `ob_atom.py`: remove self-answered #159 TODO (decision: pass indexes at call sites)
- `ob_atom.py`: remove minor optimisation suggestion from sigma loop (current loop is clear and correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)