### PR TITLE
feat(plot): spectrum axis bounds, e_ops keyword fix, plotting.ipynb updates

### DIFF
--- a/docs/usage/plotting.ipynb
+++ b/docs/usage/plotting.ipynb
@@ -141,6 +141,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3b26c63a",
+   "source": "## `field_z_profile_anim` — animated spatial profile\n\nWatch the pulse propagate through the medium. Each frame shows\nthe field envelope $|\\Omega(z)|$ at a single instant. Use the slider to scrub\nto a specific time, or press **▶ Play** to animate.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "d8633d11",
+   "source": "fig = plot.field_z_profile_anim(mbs)\nfig.show(renderer='notebook_connected')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "pulse-area-header",
    "metadata": {},
    "source": [
@@ -165,16 +179,7 @@
    "cell_type": "markdown",
    "id": "spectrum-header",
    "metadata": {},
-   "source": [
-    "## `spectrum` — frequency-domain absorption\n",
-    "\n",
-    "Computes the absorption spectrum via Fourier transform of the time-domain\n",
-    "field. This works in the linear (weak-field) regime: for strong fields the\n",
-    "result is the nonlinear transmission, not the susceptibility.\n",
-    "\n",
-    "Pass `show_dispersion=True` to add the dispersive component on a secondary\n",
-    "axis."
-   ]
+   "source": "## `spectrum` — frequency-domain absorption\n\nComputes the absorption spectrum via Fourier transform of the time-domain\nfield at `z_idx` (default: exit face). This works in the linear (weak-field)\nregime; for strong fields the result is the nonlinear transmission, not the\nsusceptibility.\n\nKey options:\n\n- `freq_range` — clip the displayed frequency axis to `|f| ≤ freq_range` (γ),\n  hiding the noisy high-frequency wings.\n- `show_dispersion=True` — add the dispersive component on a secondary axis.\n- `freq_scale=\"arcsinh\"` — compress the frequency axis nonlinearly (linear\n  near zero, log-like at large |f|) so narrow and broad features coexist.\n  `arcsinh_scale` sets the width of the linear region in γ.\n- `window` — apply a SciPy window (e.g. `\"hann\"`) to the time-domain field\n  before the FFT to reduce spectral leakage from truncated free-induction decay."
   },
   {
    "cell_type": "code",
@@ -182,10 +187,15 @@
    "id": "spectrum",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "fig = plot.spectrum(mbs, show_dispersion=True)\n",
-    "fig.show(renderer='notebook_connected')"
-   ]
+   "source": "# Narrow window around the resonance with dispersion on secondary axis\nfig = plot.spectrum(mbs, freq_range=3.0, show_dispersion=True)\nfig.show(renderer='notebook_connected')"
+  },
+  {
+   "cell_type": "code",
+   "id": "0a9f87dd",
+   "source": "# Arcsinh frequency scale (linear ±1 γ, log-like beyond) with Hann windowing\n# to reduce leakage from the free-induction decay tail\nfig = plot.spectrum(mbs, freq_scale=\"arcsinh\", arcsinh_scale=1.0, window=\"hann\")\nfig.show(renderer='notebook_connected')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/src/maxwellbloch/ob_base.py
+++ b/src/maxwellbloch/ob_base.py
@@ -191,7 +191,7 @@ class OBBase(object):
                 options["progress_bar"] = "text"
 
             self.result = qu.mesolve(
-                H, rho0, tlist, self.c_ops, e_ops, args=args, options=options
+                H, rho0, tlist, self.c_ops, e_ops=e_ops, args=args, options=options
             )
 
             self.rho = self.result.states[-1]  #  Set rho to the final state.

--- a/src/maxwellbloch/plot/spectra.py
+++ b/src/maxwellbloch/plot/spectra.py
@@ -147,6 +147,10 @@ def spectrum(
     if freq_scale == "arcsinh":
         fig.update_layout(xaxis=_arcsinh_tick_layout(freqs_clipped, arcsinh_scale))
 
+    fig.update_layout(
+        xaxis_minallowed=float(x_plot[0]),
+        xaxis_maxallowed=float(x_plot[-1]),
+    )
     return fig
 
 
@@ -199,6 +203,7 @@ def spectrum_overlay(
         )
     )
     freqs_clipped_last = None
+    x_plot_last = None
     for mbs, lbl in zip(mbs_list, labels, strict=False):
         freqs = spectral.freq_list(mbs)
         absorp = spectral.absorption(mbs, field_idx, z_idx=z_idx, window=window)
@@ -206,9 +211,15 @@ def spectrum_overlay(
             freqs, [absorp], freq_range, freq_scale, arcsinh_scale
         )
         freqs_clipped_last = freqs_clipped
+        x_plot_last = x_plot
         fig.add_trace(go.Scatter(x=x_plot, y=absorp, mode="lines", name=lbl))
 
     if freq_scale == "arcsinh" and freqs_clipped_last is not None:
         fig.update_layout(xaxis=_arcsinh_tick_layout(freqs_clipped_last, arcsinh_scale))
 
+    if x_plot_last is not None:
+        fig.update_layout(
+            xaxis_minallowed=float(x_plot_last[0]),
+            xaxis_maxallowed=float(x_plot_last[-1]),
+        )
     return fig


### PR DESCRIPTION
## Summary

- `spectra.py`: constrain spectrum x-axis zoom to the plotted frequency range via `xaxis_minallowed`/`xaxis_maxallowed`, preventing misleading empty space when panning
- `ob_base.py`: pass `e_ops` as a keyword argument to `mesolve` — avoids the qutip `FutureWarning` (required from qutip 5.3)
- `plotting.ipynb`: add `field_z_profile_anim` section; expand spectrum docs with `freq_range`, `arcsinh_scale`, and `window` examples

## Test plan

- [ ] CI passes
- [ ] Spectrum plot axis does not scroll beyond plotted range
- [ ] No qutip FutureWarning in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)